### PR TITLE
Fix: Add property bindings to playground-code-editor's value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upgrade to Lit 2.0.
 
+### Fixed
+
+- Fixed bug where the `value` property of a `<playground-code-editor>` did not take effect if set before element upgrade.
+
+### Added
+
+- It is now possible to set the `value` of a `<playground-code-editor>` using the `value` HTML attribute.
+
 ## [0.13.0] - 2021-09-14
 
 ### Changed

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -127,6 +127,7 @@ export class PlaygroundCodeEditor extends LitElement {
   // that we can set this value internally without triggering an update.
   private _value?: string;
 
+  @property()
   get value() {
     return this._value;
   }


### PR DESCRIPTION
Fixes #213 

Do you see a reason why we wouldn't want to have a property binding on the value field? We have it in our `updated` -method's switch cases so it would make sense to have it as a lit property.

There's the comment on the private value field, but the property would bind to the public getter/setter.

From my testing I didn't see stuff break, and the tests run fine, so I think this is just a missing binding and will fix the case