### PR TITLE
Replace tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <br>
-  Serverless code experiences with web components.
+  Serverless coding environments for the web.
   <br>
   <br>
   <img src="./images/preview.png" width="650">

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@
 ## Overview
 
 Playground Elements are a set of components for creating interactive editable
-code experiences on the web, with live updating previews. You can use Playground
-to:
+coding environments on the web, with live updating previews. You can use
+Playground Elements to:
 
 - Embed editable code examples in your documentation.
 - Build interactive tutorials and example galleries.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playground-elements",
   "version": "0.14.1",
-  "description": "A multi-file code editor component with live preview",
+  "description": "Serverless coding environments for the web",
   "homepage": "https://github.com/google/playground-elements#readme",
   "repository": "github:google/playground-elements",
   "type": "module",


### PR DESCRIPTION
Replaces "Serverless code experiences with web components" with "Serverless coding environments on the web".

- Making "web components" prominent kind of makes it sound like its only for editing web components, or only for projects that already use web components, etc.
- "experiences" is just a kind of a weird word to use.
- "coding" seems better than "code" because it's more obvious that it's for interactively coding.