### PR TITLE
More aggressive techniques for updating the service worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Implemented more aggressive techniques to encourage new versions of the
+  service worker to be found and activated:
+
+  - The expected version number is now included as a URL parameter to encourage
+    cache busting (e.g. `playground-service-worker.js?v=0.14.3`).
+
+  - The previous version of a service worker is now explicitly unregistered, to
+    work around cases where a previous version would never shut down to allow a
+    new version to take over, even across browser restarts.
+
+  - The previous and expected new service worker version numbers are now
+    included in console log messages, to aid in debugging.
 
 ## [0.14.2] - 2021-09-30
 

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -71,6 +71,12 @@ import {
         // if we never end up getting a new version here. That would indicate
         // that the SW and project are out of date *on the server*.
         registration.update();
+        // There seems to be a bug in Chrome where the previous version of a
+        // service worker sometimes gets stuck and never shuts down when an
+        // updating is pending, even across a full browser restart. Calling
+        // unregister here seems to reliably force the previous version to shut
+        // down.
+        registration.unregister();
       }
     }
   );


### PR DESCRIPTION
More aggressive techniques to encourage new versions of the service worker to be found and activated:

  - The expected version number is now included as a URL parameter to encourage cache busting (e.g. `playground-service-worker.js?v=0.14.3`).

  - The previous version of a service worker is now explicitly unregistered, to work around cases where a previous version would never shut down to allow a new version to take over, even across browser restarts.

  - The previous and expected new service worker version numbers are now included in console log messages, to aid in debugging.