### PR TITLE
Fix bottleneck in build causing significant preview latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed a bottleneck that prevented previews from loading until semantic
+  TypeScript errors were computed. This should significantly improve the latency
+  between updating a file and the new preview loading.
+
 - Implemented more aggressive techniques to encourage new versions of the
   service worker to be found and activated:
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bundle": "rollup -c rollup.config.js",
     "test": "wtr",
     "lint": "eslint \"src/**/*.ts\"",
-    "watch": "npm run build:lib -- --watch & rollup -c rollup.config.js -w",
+    "watch": "npm run build:lib -- --watch & NO_TERSER=1 rollup -c rollup.config.js -w",
     "serve": "web-dev-server --node-resolve --watch --open=configurator/",
     "format": "prettier src/**/*.ts --write"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,6 +56,8 @@ const terserOptions = {
   },
 };
 
+const maybeTerser = process.env.NO_TERSER ? [] : [terser(terserOptions)];
+
 export default [
   // Generate playground-service-worker-proxy.html, the HTML file + inline
   // script that proxies between a project and a service worker on a possibly
@@ -67,7 +69,7 @@ export default [
       format: 'esm',
     },
     plugins: [
-      terser(terserOptions),
+      ...maybeTerser,
       inlineHtml('playground-service-worker-proxy.html'),
     ],
   },
@@ -100,7 +102,7 @@ Distributed under an MIT license: https://codemirror.net/LICENSE */
         [/typeof exports ?===? ?['"`]object['"`]/g, 'false'],
         [/typeof define ?===? ?['"`]function['"`]/g, 'false'],
       ]),
-      terser(terserOptions),
+      ...maybeTerser,
       summary(),
     ],
   },
@@ -111,7 +113,7 @@ Distributed under an MIT license: https://codemirror.net/LICENSE */
       format: 'iife',
       exports: 'none',
     },
-    plugins: [resolve(), terser(terserOptions)],
+    plugins: [resolve(), ...maybeTerser],
   },
   {
     input: 'typescript-worker/playground-typescript-worker.js',
@@ -120,6 +122,6 @@ Distributed under an MIT license: https://codemirror.net/LICENSE */
       format: 'iife',
       exports: 'none',
     },
-    plugins: [resolve(), terser(terserOptions)],
+    plugins: [resolve(), ...maybeTerser],
   },
 ];

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -46,6 +46,23 @@ suite('MergedAsyncIterables', () => {
     assert.deepEqual(actual, expected);
   });
 
+  test('throws if iterator added after complete', async () => {
+    const merged = new MergedAsyncIterables();
+    merged.add(
+      (async function* () {
+        yield 'a';
+      })()
+    );
+    await flush(merged);
+    assert.throws(() => {
+      merged.add(
+        (async function* () {
+          yield 'b';
+        })()
+      );
+    });
+  });
+
   test('two iterables', async () => {
     const a = (async function* () {
       await raf();


### PR DESCRIPTION
Fixes an oversight in the `MergedAsyncIterables` class that caused most build output to get blocked on TypeScript semantic (type checker) errors being computed. This has a very noticeable effect on responsiveness.

Check out the difference (e.g. modify the "Hello..." template):

Before: https://lit.dev/playground/
After: https://pr543-7afcc35---lit-dev-5ftespv5na-uc.a.run.app/playground/

Also threw in a `NO_TERSER` mode for Rollup, for slightly faster dev.