### PR TITLE
Fix reloading preview iframe affecting parent window history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   TypeScript errors were computed. This should significantly improve the latency
   between updating a file and the new preview loading.
 
+- Fixed bug where parent window history entries were added every time the
+  preview reloaded.
+
 - Improvements to service worker version updates:
 
   - The service worker will require less frequent updates going forward.

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -256,10 +256,8 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     // window (on Chrome but not Firefox, and only when the parent/iframe origins
     // are different). Removing the iframe from the DOM while we initiate the
     // reload prevents a history entry from being added.
-    const parentNode = iframe.parentNode;
-    const nextSibling = iframe.nextSibling;
+    const {parentNode, nextSibling} = iframe;
     if (parentNode) {
-      iframe.nextSibling;
       iframe.remove();
     }
     // Note we can't use contentWindow.location.reload() here, because the

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -248,13 +248,27 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
   }
 
   reload = () => {
-    if (!this._iframe) {
+    const iframe = this._iframe;
+    if (!iframe) {
       return;
+    }
+    // Reloading the iframe can cause a history entry to be added to the parent
+    // window (on Chrome but not Firefox, and only when the parent/iframe origins
+    // are different). Removing the iframe from the DOM while we initiate the
+    // reload prevents a history entry from being added.
+    const parentNode = iframe.parentNode;
+    const nextSibling = iframe.nextSibling;
+    if (parentNode) {
+      iframe.nextSibling;
+      iframe.remove();
     }
     // Note we can't use contentWindow.location.reload() here, because the
     // IFrame might be on a different origin.
-    this._iframe.src = '';
-    this._iframe.src = this._indexUrl;
+    iframe.src = '';
+    iframe.src = this._indexUrl;
+    if (parentNode) {
+      parentNode.insertBefore(iframe, nextSibling);
+    }
     this._loading = true;
     this._showLoadingBar = true;
   };

--- a/src/test/fake-cdn-plugin.ts
+++ b/src/test/fake-cdn-plugin.ts
@@ -68,8 +68,9 @@ export function fakeCdnPlugin(): TestRunnerPlugin {
         // especially for when we're in a long running --watch mode session.
         const id = payload as string;
         dataMap.delete(id);
+        return true;
       }
-      return false;
+      return null;
     },
 
     serve(ctx) {

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -8,6 +8,7 @@ import {assert} from '@esm-bundle/chai';
 import {html, render} from 'lit';
 import {PlaygroundIde} from '../playground-ide.js';
 import '../playground-ide.js';
+import {executeServerCommand} from '@web/test-runner-commands';
 
 import type {ReactiveElement} from '@lit/reactive-element';
 import type {PlaygroundCodeEditor} from '../playground-code-editor.js';


### PR DESCRIPTION
Fixes a bug where every time the preview reloaded, a history entry would be added to the parent window. From my testing, this affects Chrome but not Firefox, and only when the parent/iframe origins are separate. Removing the iframe from the DOM before doing the reload, and then adding it back again, prevents this from happening.

Fixes https://github.com/google/playground-elements/issues/220

cc @castastrophe @Matsuuu 