### PR TITLE
Show useful error when service workers unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added an overlay that will display over the preview when we detect that
+  service workers are not available. One reason this can happen is using
+  Playground in Firefox private browsing mode, which does not support service
+  workers (https://bugzilla.mozilla.org/show_bug.cgi?id=1320796).
+
 ### Changed
 
 - Upgraded dependencies, including CodeMirror.

--- a/src/internal/overlay.ts
+++ b/src/internal/overlay.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+
+/**
+ * An absolutely positioned scrim with a floating message.
+ */
+@customElement('playground-internal-overlay')
+export class PlaygroundInternalOverlay extends LitElement {
+  static override styles = css`
+    :host {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      box-sizing: border-box;
+      left: 0;
+      top: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      z-index: 9;
+      background: rgba(0, 0, 0, 0.32);
+      overflow-y: auto;
+    }
+
+    #message {
+      background: #fff;
+      color: #000;
+      padding: 10px 20px;
+      border-radius: 5px;
+      box-shadow: rgba(0, 0, 0, 0.3) 0 2px 10px;
+    }
+  `;
+
+  override render() {
+    return html`<div id="message"><slot></slot></div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'playground-internal-overlay': PlaygroundInternalOverlay;
+  }
+}

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -9,6 +9,7 @@ import {customElement, property, query, state} from 'lit/decorators.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {CodeMirror} from './internal/codemirror.js';
 import playgroundStyles from './playground-styles.js';
+import './internal/overlay.js';
 import type {Diagnostic} from 'vscode-languageserver';
 
 // TODO(aomarks) Could we upstream this to lit-element? It adds much stricter
@@ -48,32 +49,6 @@ export class PlaygroundCodeEditor extends LitElement {
         border-radius: inherit;
       }
 
-      #keyboardHelpScrim {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        left: 0;
-        top: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: transparent;
-        z-index: 9;
-        pointer-events: none;
-        background: rgba(0, 0, 0, 0.32);
-      }
-
-      #keyboardHelp {
-        background: #fff;
-        color: #000;
-        padding: 20px 40px;
-        border-radius: 5px;
-        font-family: sans-serif;
-        font-size: 18px;
-        line-height: 32px;
-        box-shadow: rgba(0, 0, 0, 0.3) 0 2px 10px;
-      }
-
       .CodeMirror-foldmarker {
         font-family: sans-serif;
       }
@@ -81,6 +56,12 @@ export class PlaygroundCodeEditor extends LitElement {
         cursor: pointer;
         /* Pretty much any color from the theme is good enough. */
         color: var(--playground-code-keyword-color, #770088);
+      }
+
+      #keyboardHelp {
+        font-size: 18px;
+        font-family: sans-serif;
+        padding: 10px 20px;
       }
 
       .diagnostic {
@@ -255,12 +236,12 @@ export class PlaygroundCodeEditor extends LitElement {
         @keydown=${this._onKeyDown}
       >
         ${this._showKeyboardHelp
-          ? html`<div id="keyboardHelpScrim">
+          ? html`<playground-internal-overlay>
               <p id="keyboardHelp" part="dialog">
                 Press <strong>Enter</strong> to start editing<br />
                 Press <strong>Escape</strong> to exit editor
               </p>
-            </div>`
+            </playground-internal-overlay>`
           : nothing}
         ${this._cmDom}
         <div


### PR DESCRIPTION
Detect when service workers are not available and show a useful error. Uses the same styling that we previously used on the main editor to prevent keyboard focus trap. The main place this comes up is when using Firefox in private browsing mode, which is not currently supported (see https://bugzilla.mozilla.org/show_bug.cgi?id=1320796).

In a followup I'm also going to use this style of overlay to inform the user that something has gone wrong with service worker update, and that they may need to reload the page.

Fixes https://github.com/google/playground-elements/issues/78

<img src="https://user-images.githubusercontent.com/48894/135879645-ca4f9ddc-8738-40e0-b7c3-5694e77936bc.png" width="800px">
