### PR TITLE
Expose cursor position and token under cursor from editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Playground in Firefox private browsing mode, which does not support service
   workers (https://bugzilla.mozilla.org/show_bug.cgi?id=1320796).
 
+- Added getters for code-editor to access the cursor position, and the tokens under cursor
+
 ### Changed
 
 - Upgraded dependencies, including CodeMirror.

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -11,7 +11,6 @@ import {CodeMirror} from './internal/codemirror.js';
 import playgroundStyles from './playground-styles.js';
 import './internal/overlay.js';
 import type {Diagnostic} from 'vscode-languageserver';
-import type {Position} from 'codemirror';
 
 // TODO(aomarks) Could we upstream this to lit-element? It adds much stricter
 // types to the ChangedProperties type.
@@ -31,6 +30,11 @@ export interface EditorToken {
   end: number;
   /** Code string under the cursor. */
   string: string;
+}
+
+interface EditorPosition {
+  ch: number;
+  line: number;
 }
 
 const unreachable = (n: never) => n;
@@ -113,24 +117,27 @@ export class PlaygroundCodeEditor extends LitElement {
 
   protected _codemirror?: ReturnType<typeof CodeMirror>;
 
-  get cursorPosition(): Position | undefined {
-    const cm = this._codemirror;
-    if (!cm) return undefined;
+  get cursorPosition(): EditorPosition {
+    const cursor = this._codemirror?.getCursor('start');
+    if (!cursor) return {ch: 0, line: 0};
 
-    return cm.getCursor('start');
+    return {
+      ch: cursor.ch,
+      line: cursor.line,
+    };
   }
 
-  get cursorIndex(): number | undefined {
+  get cursorIndex(): number {
     const cm = this._codemirror;
-    if (!cm) return undefined;
+    if (!cm) return 0;
 
     const cursorPosition = cm.getCursor('start');
     return cm.indexFromPos(cursorPosition);
   }
 
-  get tokenUnderCursor(): EditorToken | undefined {
+  get tokenUnderCursor(): EditorToken {
     const cm = this._codemirror;
-    if (!cm) return undefined;
+    if (!cm) return {start: 0, end: 0, string: ''};
 
     const cursorPosition = cm.getCursor('start');
     const token = cm.getTokenAt(cursorPosition);

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -494,6 +494,7 @@ suite('playground-ide', () => {
     assert.isFalse(ide.modified);
     assert.isFalse(ide.modified);
   });
+
   test('returns the correct cursor position and index', async () => {
     const ide = document.createElement('playground-ide');
     ide.sandboxBaseUrl = '/';
@@ -525,9 +526,10 @@ suite('playground-ide', () => {
     assert.equal(editor.value, codeToAdd);
     assert.equal(editor.cursorIndex, codeToAdd.length);
     const cursorPosition = editor.cursorPosition;
-    assert.equal(cursorPosition?.line, 1);
-    assert.equal(cursorPosition?.ch, 23);
+    assert.equal(cursorPosition.line, 1);
+    assert.equal(cursorPosition.ch, 23);
   });
+
   test('returns the token under cursor', async () => {
     const ide = document.createElement('playground-ide');
     ide.sandboxBaseUrl = '/';
@@ -556,9 +558,9 @@ suite('playground-ide', () => {
 
     const tokenUnderCursor = editor.tokenUnderCursor;
 
-    assert.equal(tokenUnderCursor?.start, 0);
-    assert.equal(tokenUnderCursor?.end, 7);
-    assert.equal(tokenUnderCursor?.string, 'console');
+    assert.equal(tokenUnderCursor.start, 0);
+    assert.equal(tokenUnderCursor.end, 7);
+    assert.equal(tokenUnderCursor.string, 'console');
   });
 
   test('reloading preview does not modify history', async () => {


### PR DESCRIPTION
Exposed useful information for diagnostic and language server interactions from the code-editor to the outside.
