### PR TITLE
Fix positioning of no-service-worker error overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed positioning of overlay that displays over previews when service workers
   are not available so that it is constrained to the preview, rather than the
-  nearest containing relative ancestor.
+  nearest containing positioned ancestor.
 
 ## [0.14.3] - 2021-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed positioning of overlay that displays over previews when service workers
+  are not available so that it is constrained to the preview, rather than the
+  nearest containing relative ancestor.
 
 ## [0.14.3] - 2021-10-06
 

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -28,6 +28,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
       background: white;
       font-family: sans-serif;
       height: 350px;
+      position: relative; /* for the error message overlay */
     }
 
     #toolbar {


### PR DESCRIPTION
Fix an oversight in https://github.com/google/playground-elements/pull/224.

When service workers are not available, such as in Firefox in private browsing mode, we display a message over the preview. The overlay is absolutely positioned, and was intended to cover up just the preview (since the editor still works fine). However, since the preview is not necessarily itself positioned, the overlay was instead covering the next nearest positioned ancestor, which in the case of lit.dev was the entire window.

I didn't notice this because I only tested it in playground-ide, which positions the preview, but not when preview is used in a custom layout, such as in lit.dev.

### Before
![image](https://user-images.githubusercontent.com/48894/136305996-6f15b692-aebe-4087-b764-9ce23dc006e5.png)

### After
![image](https://user-images.githubusercontent.com/48894/136305986-6862ac8b-76df-4951-bba7-8a5733cf7c11.png)

