### PR TITLE
chore: Fix typo on importmap examples and reference to latest lit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ from unpkg.com at the latest version.
 import {html} from 'lit';
 
 // What playground serves:
-import {html} from './node_modules/lit@2.0.0/index.js';
+import {html} from './node_modules/lit@2.0.2/index.js';
 
 // What playground fetches behind-the-scenes:
 // https://unpkg.com/lit@latest
@@ -280,7 +280,7 @@ map. This works exactly like it does when using NPM locally.
 ```json
 {
   "dependencies": {
-    "lit": "^2.0.0"
+    "lit": "^2.0.2"
   }
 }
 ```
@@ -309,8 +309,8 @@ module:
   "files": { ... },
   "importMap": {
     "imports": {
-      "lit": "https://cdn.skypack.dev/lit@^2.0.0",
-      "lit/": "https://cdn.skypack.dev/lit@^2.0.0/"
+      "lit": "https://cdn.skypack.dev/lit@^2.0.2",
+      "lit/": "https://cdn.skypack.dev/lit@^2.0.2/"
     }
   }
 }
@@ -323,8 +323,8 @@ When using inline project files, you can specify your import map like so:
   <script type="sample/importmap">
     {
       "imports": {
-        "lit": "https://cdn.skypack.dev/lit@^2.0.0,
-        "lit/": "https://cdn.skypack.dev/lit@^2.0.0/"
+        "lit": "https://cdn.skypack.dev/lit@^2.0.2",
+        "lit/": "https://cdn.skypack.dev/lit@^2.0.2/"
       }
     }
   </script>


### PR DESCRIPTION
Heya, Trying to get back into speed with contributing. Set up some demos and noticed that the import maps demos had a typo making it not build

- Fix import map closing quotes
- Make reference in imports to lit 2.0.2