### PR TITLE
Fix missing aria-label attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed missing `aria-label` attributes on the reload button, file context menu
+  button, and new file button
 
 ## [0.14.6] - 2021-10-18
 

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -191,7 +191,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
         <span id="location" part="preview-location"> ${this.location}</span>
         <mwc-icon-button
           id="reload-button"
-          label="Reload preview"
+          aria-label="Reload preview"
           part="preview-reload-button"
           ?disabled=${!this._indexUrl}
           @click=${this.reload}

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -175,7 +175,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
               ${label || name}
               ${this.editableFileSystem
                 ? html`<mwc-icon-button
-                    label="File menu"
+                    aria-label="File menu"
                     class="menu-button"
                     @click=${this._onOpenMenu}
                   >
@@ -200,7 +200,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
         ? html`
             <mwc-icon-button
               class="add-file-button"
-              label="New file"
+              aria-label="New file"
               @click=${this._onClickAddFile}
             >
               <!-- Source: https://material.io/resources/icons/?icon=add&style=baseline -->


### PR DESCRIPTION
MWC replaced the "label" attribute with "aria-label" on some elements and I didn't notice this in the last version bump.