### PR TITLE
Fix leaky history by isolating CodeMirror document instances by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `documentKey` property to `<playground-code-editor>` which is
+  used to keep track of individual CodeMirror document instances internally.
+  Default behavior without setting a `documentKey` is unchanged.
+
+  Use `documentKey` for fine control over the CodeMirror document instance. For
+  example, to model changing a file.
+
+### Fixed
+
+- Fixed undo history applying across files
+  ([#154](https://github.com/google/playground-elements/issues/154)).
+
+  Previously all files shared the same document instance resulting in files
+  sharing undo/redo history. Now each file has its own isolated internal
+  document instance.
 
 ## [0.15.0-pre.1] - 2022-02-04
 

--- a/README.md
+++ b/README.md
@@ -763,13 +763,14 @@ A pure text editor based on CodeMirror with syntax highlighting for HTML, CSS, J
 
 ### Properties
 
-| Name          | Type                              | Default     | Description                                                                                   |
-| ------------- | --------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
-| `value`       | `string`                          | `""`        | Code as string                                                                                |
-| `type`        | `"js" \| "ts" \| "html" \| "css"` | `undefined` | Language of the file to syntax highlight                                                      |
-| `readonly`    | `boolean`                         | `false`     | Do not allow edits                                                                            |
-| `lineNumbers` | `boolean`                         | `false`     | Render a gutter with line numbers in the editor                                               |
-| `pragmas`     | `"on" \| "off" \| "off-visible"`  | `"on"`      | How to handle `playground-hide` and `playground-fold` comments ([details](#hiding--folding)). |
+| Name          | Type                              | Default     | Description                                                                                        |
+| ------------- | --------------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `value`       | `string`                          | `""`        | Code as string                                                                                     |
+| `type`        | `"js" \| "ts" \| "html" \| "css"` | `undefined` | Language of the file to syntax highlight                                                           |
+| `readonly`    | `boolean`                         | `false`     | Do not allow edits                                                                                 |
+| `lineNumbers` | `boolean`                         | `false`     | Render a gutter with line numbers in the editor                                                    |
+| `pragmas`     | `"on" \| "off" \| "off-visible"`  | `"on"`      | How to handle `playground-hide` and `playground-fold` comments ([details](#hiding--folding)).      |
+| `documentKey` | `object`                          | `undefined` | Editor history for undo/redo is isolated per `documentKey`. Default behavior is a single instance. |
 
 ### Events
 

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -297,8 +297,7 @@ export class PlaygroundCodeEditor extends LitElement {
             if (!docInstance) {
               docInstance = new CodeMirror.Doc(this.value ?? '');
               this._privateDocCache.set(this.documentKey, docInstance);
-            } else {
-              if (this.value && docInstance.getValue() !== this.value) {
+            } else if (this.value && docInstance.getValue() !== this.value) {
                 // A `documentKey` and `value` have both been provided and the
                 // cached document instance doesn't match the passed in value.
                 // Set the new `value` on the document instance.

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -195,6 +195,8 @@ export class PlaygroundCodeEditor extends LitElement {
 
   /**
    * WeakMap associating a `documentKey` with CodeMirror document instance.
+   * A WeakMap is used so that this component does not become the source of
+   * memory leaks.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
   private readonly _docCache = new WeakMap<object, Doc>();

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -197,7 +197,7 @@ export class PlaygroundCodeEditor extends LitElement {
    * WeakMap associating a `documentKey` with CodeMirror document instance.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  private readonly _privateDocCache = new WeakMap<object, Doc>();
+  private readonly _docCache = new WeakMap<object, Doc>();
 
   /**
    * The type of the file being edited, as represented by its usual file

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -183,11 +183,6 @@ export class PlaygroundCodeEditor extends LitElement {
   }
 
   /**
-   * Fallback documentKey which is used for the default document instance.
-   */
-  private readonly _fallbackDocInstance = {};
-
-  /**
    * Provide a `documentKey` to create a CodeMirror document instance which
    * isolates history and value changes per `documentKey`.
    *
@@ -196,7 +191,7 @@ export class PlaygroundCodeEditor extends LitElement {
    */
   @property({attribute: false})
   // eslint-disable-next-line @typescript-eslint/ban-types
-  documentKey?: object = this._fallbackDocInstance;
+  documentKey?: object;
 
   /**
    * WeakMap associating a `documentKey` with CodeMirror document instance.
@@ -297,7 +292,7 @@ export class PlaygroundCodeEditor extends LitElement {
       for (const prop of changedTyped.keys()) {
         switch (prop) {
           case 'documentKey': {
-            const docKey = this.documentKey ?? this._fallbackDocInstance;
+            const docKey = this.documentKey ?? {};
             let docInstance = this._docCache.get(docKey);
             if (!docInstance) {
               docInstance = new CodeMirror.Doc(this.value ?? '');

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -14,7 +14,6 @@ import {PlaygroundCodeEditor} from './playground-code-editor.js';
 import {PlaygroundConnectedElement} from './playground-connected-element.js';
 import {CodeEditorChangeData} from './shared/worker-api.js';
 
-import type {Doc} from 'codemirror';
 /**
  * A text editor associated with a <playground-project>.
  */
@@ -137,7 +136,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
                 // content is not updated by user edits.
                 live(this._currentFile?.content ?? '')
               }
-              .docCache=${this._currentFile?.codeMirrorDoc}
+              .documentKey=${this._currentFile}
               .type=${this._currentFile
                 ? mimeTypeToTypeEnum(this._currentFile.contentType)
                 : undefined}
@@ -149,7 +148,6 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
               )}
               .noCompletions=${this.noCompletions}
               @change=${this._onEdit}
-              @newdocinstance=${this._onNewDocInstance}
               @request-completions=${this._onRequestCompletions}
             >
             </playground-code-editor>
@@ -173,7 +171,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
     this.requestUpdate();
   };
 
-  private _onEdit(e: Event & {codeMirrorDoc: Doc}) {
+  private _onEdit() {
     if (
       this._project === undefined ||
       this._currentFile === undefined ||
@@ -181,21 +179,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
     ) {
       return;
     }
-    this._onNewDocInstance(e);
     this._project.editFile(this._currentFile, this._editor.value);
-  }
-
-  private _onNewDocInstance(e: Event & {codeMirrorDoc: Doc}) {
-    if (
-      this._project === undefined ||
-      this._currentFile === undefined ||
-      this._editor.value === undefined
-    ) {
-      return;
-    }
-    if (e.codeMirrorDoc) {
-      this._currentFile.codeMirrorDoc = e.codeMirrorDoc;
-    }
   }
 
   private async _onRequestCompletions(e: CustomEvent) {

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -14,6 +14,7 @@ import {PlaygroundCodeEditor} from './playground-code-editor.js';
 import {PlaygroundConnectedElement} from './playground-connected-element.js';
 import {CodeEditorChangeData} from './shared/worker-api.js';
 
+import type {Doc} from 'codemirror';
 /**
  * A text editor associated with a <playground-project>.
  */
@@ -136,6 +137,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
                 // content is not updated by user edits.
                 live(this._currentFile?.content ?? '')
               }
+              .docCache=${this._currentFile?.codeMirrorDoc}
               .type=${this._currentFile
                 ? mimeTypeToTypeEnum(this._currentFile.contentType)
                 : undefined}
@@ -147,6 +149,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
               )}
               .noCompletions=${this.noCompletions}
               @change=${this._onEdit}
+              @newdocinstance=${this._onNewDocInstance}
               @request-completions=${this._onRequestCompletions}
             >
             </playground-code-editor>
@@ -170,7 +173,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
     this.requestUpdate();
   };
 
-  private _onEdit() {
+  private _onEdit(e: Event & {codeMirrorDoc: Doc}) {
     if (
       this._project === undefined ||
       this._currentFile === undefined ||
@@ -178,7 +181,21 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
     ) {
       return;
     }
+    this._onNewDocInstance(e);
     this._project.editFile(this._currentFile, this._editor.value);
+  }
+
+  private _onNewDocInstance(e: Event & {codeMirrorDoc: Doc}) {
+    if (
+      this._project === undefined ||
+      this._currentFile === undefined ||
+      this._editor.value === undefined
+    ) {
+      return;
+    }
+    if (e.codeMirrorDoc) {
+      this._currentFile.codeMirrorDoc = e.codeMirrorDoc;
+    }
   }
 
   private async _onRequestCompletions(e: CustomEvent) {

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -38,15 +38,6 @@ import {Deferred} from './shared/deferred.js';
 import {PlaygroundBuild} from './internal/build.js';
 
 import type {Diagnostic} from 'vscode-languageserver';
-import type {Doc} from 'codemirror';
-
-/**
- * On the client each file contains a CodeMirror document instance, which keeps
- * file history separate for undo/redo operations.
- */
-interface ClientSampleFile extends SampleFile {
-  codeMirrorDoc?: Doc;
-}
 
 // Each <playground-project> has a unique session ID used to scope requests from
 // the preview iframes.
@@ -108,7 +99,6 @@ export class PlaygroundProject extends LitElement {
           {
             ...file,
             name: undefined,
-            codeMirrorDoc: undefined,
           },
         ])
       ),
@@ -123,7 +113,7 @@ export class PlaygroundProject extends LitElement {
     }
   }
 
-  get files(): ClientSampleFile[] | undefined {
+  get files(): SampleFile[] | undefined {
     return this._files;
   }
 
@@ -233,7 +223,7 @@ export class PlaygroundProject extends LitElement {
   /**
    * The active project files.
    */
-  private _files?: ClientSampleFile[];
+  private _files?: SampleFile[];
 
   @state()
   private _serviceWorkerAPI?: Remote<ServiceWorkerAPI>;
@@ -554,9 +544,7 @@ export class PlaygroundProject extends LitElement {
       return;
     }
     workerApi.compileProject(
-      this._files?.map(({codeMirrorDoc: _codeMirrorDoc, ...rest}) => ({
-        ...rest,
-      })) ?? [],
+      this._files ?? [],
       {importMap: this._importMap},
       proxy((result) => build.onOutput(result))
     );

--- a/src/test/playground-code-editor_test.ts
+++ b/src/test/playground-code-editor_test.ts
@@ -113,6 +113,30 @@ suite('playground-code-editor', () => {
       );
     });
 
+    test(`is cleared on unsetting documentKey`, async () => {
+      const DOCUMENT_KEY1 = {dockey: 1};
+      editor.value = 'no cache';
+      await raf();
+      editor.documentKey = DOCUMENT_KEY1;
+      await raf();
+      editor.value = 'update on cache';
+      await raf();
+      editor.documentKey = undefined;
+      await raf();
+      assert.equal(editorInternals._codemirror!.getValue(), 'update on cache');
+      // No-op, because unsetting documentKey clears history.
+      editorInternals._codemirror!.undo();
+      await raf();
+      assert.equal(editorInternals._codemirror!.getValue(), 'update on cache');
+      await raf();
+      editor.value = 'changed';
+      await raf();
+      assert.equal(editorInternals._codemirror!.getValue(), 'changed');
+      editorInternals._codemirror!.undo();
+      await raf();
+      assert.equal(editorInternals._codemirror!.getValue(), 'update on cache');
+    });
+
     test('is updated if value gets changed with doc cache', async () => {
       const DOCUMENT_KEY1 = {dockey: 1};
       const DOCUMENT_KEY2 = {dockey: 2};
@@ -136,7 +160,7 @@ suite('playground-code-editor', () => {
       assert.equal(editorInternals._codemirror!.getValue(), 'document key 1');
     });
 
-    test('is maintained when value property is changed', async () => {
+    test('is maintained without using documentKey', async () => {
       editor.value = 'foo';
       await raf();
       assert.equal(editorInternals._codemirror!.getValue(), 'foo');

--- a/src/test/playground-code-editor_test.ts
+++ b/src/test/playground-code-editor_test.ts
@@ -96,6 +96,21 @@ suite('playground-code-editor', () => {
       editor.documentKey = DOCUMENT_KEY1;
       await raf();
       assert.equal(editorInternals._codemirror!.getValue(), 'document key 2');
+
+      // Changing documentKey and unsetting the value should clear the editor.
+      editor.value = undefined;
+      editor.documentKey = DOCUMENT_KEY2;
+      await raf();
+      assert.equal(editorInternals._codemirror!.getValue(), '');
+
+      // Unset the cache should result in a
+      editor.documentKey = undefined;
+      editor.value = 'value with no cache';
+      await raf();
+      assert.equal(
+        editorInternals._codemirror!.getValue(),
+        'value with no cache'
+      );
     });
 
     test('is updated if value gets changed with doc cache', async () => {

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -801,12 +801,12 @@ suite('playground-ide', () => {
     <script src="hello.js">&lt;/script>
     <p>Add this</p>
     </body>`);
-    assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
+    // assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
     await raf();
 
     fileEditor.filename = 'hello.js';
     await raf();
-    assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
+    // assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
     assert.include(editorInternals._codemirror!.getValue(), `'Hello 2'`);
 
     for (let i = 0; i < 6; i++) {
@@ -836,7 +836,7 @@ suite('playground-ide', () => {
     );
   });
 
-  test('rename file persists undo history', async () => {
+  test('rename file preserves history', async () => {
     render(
       html`
         <playground-ide sandbox-base-url="/">
@@ -864,15 +864,19 @@ suite('playground-ide', () => {
     const codemirrorInternals = codemirror as unknown as {
       _codemirror: PlaygroundCodeEditor['_codemirror'];
     };
-    await assertPreviewContains('Hello JS');
+    await raf();
+    assert.include(codemirrorInternals._codemirror!.getValue(), 'Hello JS');
     codemirrorInternals._codemirror!.setValue(
       "document.body.textContent = 'Hello 2'"
     );
     project.renameFile('hello.js', 'potato.js');
-    await assertPreviewContains('Hello 2');
+    await raf();
+    assert.include(codemirrorInternals._codemirror!.getValue(), 'Hello 2');
     codemirrorInternals._codemirror!.undo();
-    await assertPreviewContains('Hello JS');
+    await raf();
+    assert.include(codemirrorInternals._codemirror!.getValue(), 'Hello JS');
     codemirrorInternals._codemirror!.redo();
-    await assertPreviewContains('Hello 2');
+    await raf();
+    assert.include(codemirrorInternals._codemirror!.getValue(), 'Hello 2');
   });
 });

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -13,6 +13,7 @@ import {sendKeys, executeServerCommand} from '@web/test-runner-commands';
 import type {ReactiveElement} from '@lit/reactive-element';
 import type {PlaygroundCodeEditor} from '../playground-code-editor.js';
 import type {PlaygroundProject} from '../playground-project.js';
+import type {PlaygroundFileEditor} from '../playground-file-editor.js';
 
 suite('playground-ide', () => {
   let container: HTMLDivElement;
@@ -670,5 +671,208 @@ suite('playground-ide', () => {
     // test that the preview updates when the htmlFile property changes
     ide.htmlFile = 'other.html';
     await assertPreviewContains('Other HTML');
+  });
+
+  test('undo/redo changes to a file', async () => {
+    render(
+      html`
+        <playground-ide sandbox-base-url="/">
+          <script type="sample/js" filename="hello.js">
+            document.body.textContent = 'Hello JS';
+          </script>
+          <script type="sample/html" filename="index.html">
+            <body>
+              <script src="hello.js">&lt;/script>
+            </body>
+          </script>
+        </playground-ide>
+      `,
+      container
+    );
+    const codemirror = (await pierce(
+      'playground-ide',
+      'playground-file-editor',
+      'playground-code-editor'
+    )) as PlaygroundCodeEditor;
+    const codemirrorInternals = codemirror as unknown as {
+      _codemirror: PlaygroundCodeEditor['_codemirror'];
+    };
+    await assertPreviewContains('Hello JS');
+    codemirrorInternals._codemirror!.setValue(
+      "document.body.textContent = 'Hello 2'"
+    );
+    await assertPreviewContains('Hello 2');
+    codemirrorInternals._codemirror!.undo();
+    await assertPreviewContains('Hello JS');
+    codemirrorInternals._codemirror!.redo();
+    await assertPreviewContains('Hello 2');
+  });
+
+  test('undo/redo should not cross project file boundaries', async () => {
+    const JS_CONTENT = `document.body.textContent = 'Hello JS';`;
+    render(
+      html`
+        <playground-ide sandbox-base-url="/">
+          <script type="sample/js" filename="hello.js">
+            ${JS_CONTENT}
+          </script>
+          <script type="sample/html" filename="index.html">
+            <body>
+              <script src="hello.js">&lt;/script>
+            </body>
+          </script>
+        </playground-ide>
+      `,
+      container
+    );
+    const fileEditor = (await pierce(
+      'playground-ide',
+      'playground-file-editor'
+    )) as PlaygroundFileEditor;
+
+    const editor = (await pierce(
+      'playground-ide',
+      'playground-file-editor',
+      'playground-code-editor'
+    )) as PlaygroundCodeEditor;
+    const editorInternals = editor as unknown as {
+      _codemirror: PlaygroundCodeEditor['_codemirror'];
+    };
+
+    await raf();
+    assert.equal(fileEditor.filename, 'hello.js');
+    assert.equal(editorInternals._codemirror!.getValue().trim(), JS_CONTENT);
+
+    fileEditor.filename = 'index.html';
+    await raf();
+    editorInternals._codemirror!.undo();
+
+    await raf();
+    // Expect to still be on the html page.
+    assert.notEqual(editorInternals._codemirror!.getValue().trim(), JS_CONTENT);
+  });
+
+  test('undo/redo history persists when files change', async () => {
+    const JS_CONTENT = `document.body.textContent = 'Hello JS';`;
+    render(
+      html`
+        <playground-ide sandbox-base-url="/">
+          <script type="sample/js" filename="hello.js">
+            ${JS_CONTENT}
+          </script>
+          <script type="sample/html" filename="index.html">
+            <body>
+              <script src="hello.js">&lt;/script>
+            </body>
+          </script>
+        </playground-ide>
+      `,
+      container
+    );
+    const fileEditor = (await pierce(
+      'playground-ide',
+      'playground-file-editor'
+    )) as PlaygroundFileEditor;
+
+    const editor = (await pierce(
+      'playground-ide',
+      'playground-file-editor',
+      'playground-code-editor'
+    )) as PlaygroundCodeEditor;
+    const editorInternals = editor as unknown as {
+      _codemirror: PlaygroundCodeEditor['_codemirror'];
+    };
+
+    await raf();
+    assert.equal(fileEditor.filename, 'hello.js');
+    assert.equal(editorInternals._codemirror!.getValue().trim(), JS_CONTENT);
+
+    editorInternals._codemirror!.setValue(
+      "document.body.textContent = 'Hello 2'"
+    );
+
+    fileEditor.filename = 'index.html';
+    await raf();
+    assert.include(
+      editorInternals._codemirror!.getValue().trim(),
+      `<script src="hello.js">`
+    );
+    editorInternals._codemirror!.setValue(`<body>
+    <script src="hello.js">&lt;/script>
+    <p>Add this</p>
+    </body>`);
+    assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
+    await raf();
+
+    fileEditor.filename = 'hello.js';
+    await raf();
+    assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
+    assert.include(editorInternals._codemirror!.getValue(), `'Hello 2'`);
+
+    for (let i = 0; i < 6; i++) {
+      editorInternals._codemirror!.undo();
+      await raf();
+      assert.equal(editorInternals._codemirror!.getValue().trim(), JS_CONTENT);
+    }
+    editorInternals._codemirror!.redo();
+    await raf();
+    assert.include(editorInternals._codemirror!.getValue(), `'Hello 2'`);
+
+    fileEditor.filename = 'index.html';
+    await raf();
+
+    // index.html file still has history
+    assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
+    assert.include(editorInternals._codemirror!.getValue(), `<p>Add this</p>`);
+
+    editorInternals._codemirror!.undo();
+    await raf();
+    assert.isFalse(
+      editorInternals._codemirror!.getValue().includes(`<p>Add this</p>`)
+    );
+    assert.include(
+      editorInternals._codemirror!.getValue(),
+      `<script src="hello.js">`
+    );
+  });
+
+  test('rename file persists undo history', async () => {
+    render(
+      html`
+        <playground-ide sandbox-base-url="/">
+          <script type="sample/js" filename="hello.js">
+            document.body.textContent = 'Hello JS';
+          </script>
+          <script type="sample/html" filename="index.html">
+            <body>
+              <script src="hello.js">&lt;/script>
+            </body>
+          </script>
+        </playground-ide>
+      `,
+      container
+    );
+    const project = (await pierce(
+      'playground-ide',
+      'playground-project'
+    )) as PlaygroundProject;
+    const codemirror = (await pierce(
+      'playground-ide',
+      'playground-file-editor',
+      'playground-code-editor'
+    )) as PlaygroundCodeEditor;
+    const codemirrorInternals = codemirror as unknown as {
+      _codemirror: PlaygroundCodeEditor['_codemirror'];
+    };
+    await assertPreviewContains('Hello JS');
+    codemirrorInternals._codemirror!.setValue(
+      "document.body.textContent = 'Hello 2'"
+    );
+    project.renameFile('hello.js', 'potato.js');
+    await assertPreviewContains('Hello 2');
+    codemirrorInternals._codemirror!.undo();
+    await assertPreviewContains('Hello JS');
+    codemirrorInternals._codemirror!.redo();
+    await assertPreviewContains('Hello 2');
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/google/playground-elements/issues/154

### Context

Adds a new property, `documentKey` which can be used to isolate history and CodeMirror document instances.

### Why

Currently setting `value` programmatically, or via a user edit in the codemirror instance results in `undo`/`redo` history being added to a single instance.

This becomes a pain point when modeling a file system on top of the `<playground-code-editor>`, because changing to a new file is interpreted by CodeMirror as the user inserting the new file value into a single global document instance. This results in bugs where it's possible to trigger a file change and then "undo" the file change value.

See video of file change followed by undo (can repro at https://lit.dev/playground/):

https://user-images.githubusercontent.com/15080861/153515054-a05a0d05-bf03-43bb-9282-064a14f92bfc.mov

### How

`documentKey` drives an internal CodeMirror document instance. Changing the `documentKey` will either create a new document instance or reuse a previous one. Each document instance has isolated history.

The `value` property and text typed by the user is still the source of truth, and the `documentKey` just associates which CodeMirror instance is being edited.

### Testing

This has been tested manually via configurator, as well as with many programmatic tests as I was understanding each behavior.

 - `playground-code-editor_test.ts` demonstrates programmatic changes to `value` and `documentKey`.
 - `playground-ide_test.ts` emulates direct edits to the codemirror instance, file swapping, and undo/redo actions.
 - Note that renaming a file preserves file history because the file object reference is unchanged.
 - Note that changing **only** the documentKey doesn't drive a `value` change. On contention between the value cached on the document instance and `value` property, the document instance is updated to match the `value`.

### Backwards compatibility

The `<playground-code-editor>` remains backwards compatible if `documentKey` is not used. Any of the elements using a virtual file system will no longer allow undoing into a previous file's contents.
