### PR TITLE
Fix unescaping only a single closing script tag in playground-ide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   sharing undo/redo history. Now each file has its own isolated internal
   document instance.
 
+- Fixed only a single closing script tag unescaping in html files using
+  playground-ide
+  ([#251](https://github.com/google/playground-elements/issues/251)).
+
 ## [0.15.0-pre.1] - 2022-02-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ your `<playground-ide>` or `<playground-project>`, using the following attribute
 | `hidden`              | If present, the file won't be visible in `playground-tab-bar`.                                                        |
 | `preserve-whitespace` | Disable the default behavior where leading whitespace that is common to all lines is removed.                         |
 
-Be sure to escape closing `</script>` tags within your source as `<&lt;script>`.
+Be sure to escape closing `</script>` tags within your source as `&lt;script>`.
 
 ```html
 <playground-project>

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -386,8 +386,12 @@ export class PlaygroundProject extends LitElement {
         continue;
       }
       const fileType = typeAttr.substring('sample/'.length);
-      // TODO (justinfagnani): better entity unescaping
-      let content = s.textContent!.replace('&lt;', '<');
+      let content = s.textContent ?? '';
+      if (fileType === 'html') {
+        // Replace usages of `&lt;/script>` with `</script>`. Match against
+        // `&lt;/` so that other usages of &lt; aren't replaced.
+        content = content.replace(/&lt;\//g, '</');
+      }
       if (!s.hasAttribute('preserve-whitespace')) {
         content = outdent(content);
       }

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -105,6 +105,40 @@ suite('playground-ide', () => {
     await assertPreviewContains('Hello HTML');
   });
 
+  test('handles multiple script tags', async () => {
+    render(
+      html`
+        <playground-ide sandbox-base-url="/">
+          <script type="sample/html" filename="index.html">
+            <script>console.log('hello');&lt;/script>
+            <script>console.log('potato');&lt;/script>
+          </script>
+        </playground-ide>
+      `,
+      container
+    );
+
+    const editor = (await pierce(
+      'playground-ide',
+      'playground-file-editor',
+      'playground-code-editor'
+    )) as PlaygroundCodeEditor;
+    const editorInternals = editor as unknown as {
+      _codemirror: PlaygroundCodeEditor['_codemirror'];
+    };
+    // Wait for the editor to instantiate.
+    await raf();
+
+    assert.include(
+      editorInternals._codemirror?.getValue(),
+      `<script>console.log('hello');</script>`
+    );
+    assert.include(
+      editorInternals._codemirror?.getValue(),
+      `<script>console.log('potato');</script>`
+    );
+  });
+
   test('renders JS', async () => {
     render(
       html`


### PR DESCRIPTION
Fixes https://github.com/google/playground-elements/issues/251

Previous logic only unescapes a single `&lt;`. Fixed by unescaping all instances of `&lt;/` such that we don't over-replace intentional escapes.

This might be a breaking change since previously any sample file with any `&lt;` would have the first one replaced with `<`. The new behavior should occur more closely to what we document, and limited to only `sample/html` files.

Added a unit test (that failed first).

Alternatively could make the unescaping logic even more aggressive and match for `&lt/script>`.



