### PR TITLE
Fix duplicate names on completion items

### DIFF
--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -683,34 +683,19 @@ export class PlaygroundCodeEditor extends LitElement {
       return markedObjectName;
     }
 
-    let padding = 0;
-    const markedObjectHTML = html`
-      ${matches.map((match) => {
-        const firstMatchingIndex = match.indices[0];
-        const start = firstMatchingIndex[0];
-        const end = firstMatchingIndex[1];
+    const firstMatch = matches[0];
 
-        const preMarkContent = markedObjectName?.substring(0, start + padding);
+    const firstMatchingIndex = firstMatch.indices[0];
+    const start = firstMatchingIndex[0];
+    const end = firstMatchingIndex[1];
 
-        const markedContent = markedObjectName?.substring(
-          start + padding,
-          end + padding + 1
-        );
+    const preMarkContent = markedObjectName?.substring(0, start);
+    const markedContent = markedObjectName?.substring(start, end + 1);
+    const postMarkedContent = markedObjectName?.substring(end + 1);
 
-        const postMarkedContent = markedObjectName?.substring(
-          end + padding + 1
-        );
-        const markedHTML = html`
-          ${preMarkContent}<mark>${markedContent}</mark>${postMarkedContent}
-        `;
-        // As the matching is done in a fuzzy manner, we might have multiple matching
-        // indices in the completion word. In these situations, we need to pad out the
-        // matching positions, by the length of our already appended mark -tags.
-        padding += '<mark></mark>'.length;
-        return markedHTML;
-      })}
+    return html`
+      ${preMarkContent}<mark>${markedContent}</mark>${postMarkedContent}
     `;
-    return markedObjectHTML;
   }
 
   private _showCompletions() {

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -677,36 +677,38 @@ export class PlaygroundCodeEditor extends LitElement {
   ): TemplateResult | string {
     const markedObjectName = objectName ?? '';
     const matches = completionData?.matches ?? [];
-    let padding = 0;
     if (matches.length <= 0) {
       // In the situation, that none of the input matches with the
       // completion item suggestion, we exit early, leaving the objectName unmarked.
       return markedObjectName;
     }
 
+    let padding = 0;
     const markedObjectHTML = html`
-      ${matches.map(
-        (match) => html`
-          ${match.indices.map((ind) => {
-            const start = ind[0];
-            const end = ind[1];
-            const markedHTML = html`
-              ${markedObjectName?.substring(
-                0,
-                start + padding
-              )}<mark>${markedObjectName?.substring(
-                start + padding,
-                end + padding + 1
-              )}</mark>${markedObjectName?.substring(end + padding + 1)}
-            `;
-            // As the matching is done in a fuzzy manner, we might have multiple matching
-            // indices in the completion word. In these situations, we need to pad out the
-            // matching positions, by the length of our already appended mark -tags.
-            padding += '<mark></mark>'.length;
-            return markedHTML;
-          })}
-        `
-      )}
+      ${matches.map((match) => {
+        const firstMatchingIndex = match.indices[0];
+        const start = firstMatchingIndex[0];
+        const end = firstMatchingIndex[1];
+
+        const preMarkContent = markedObjectName?.substring(0, start + padding);
+
+        const markedContent = markedObjectName?.substring(
+          start + padding,
+          end + padding + 1
+        );
+
+        const postMarkedContent = markedObjectName?.substring(
+          end + padding + 1
+        );
+        const markedHTML = html`
+          ${preMarkContent}<mark>${markedContent}</mark>${postMarkedContent}
+        `;
+        // As the matching is done in a fuzzy manner, we might have multiple matching
+        // indices in the completion word. In these situations, we need to pad out the
+        // matching positions, by the length of our already appended mark -tags.
+        padding += '<mark></mark>'.length;
+        return markedHTML;
+      })}
     `;
     return markedObjectHTML;
   }


### PR DESCRIPTION
Fixes the duplication bug discussed here https://github.com/lit/lit.dev/pull/689

- Fix completion items showing the name multiple times in cases where
  there were multiple incdices matching

- Clean up and make completion item marking clearer code wise

