### PR TITLE
Tweak CodeMirror hint styles

### DIFF
--- a/playground-styles.css
+++ b/playground-styles.css
@@ -388,7 +388,7 @@ div.CodeMirror-dragcursors {
 
   background: var(--playground-code-background, white);
   font-size: var(--playground-code-font-size, 14px);
-  font-family: inherit;
+  font-family: var(--playground-code-font-family, monospace);
 
   max-height: 20em;
   width: 600px;
@@ -399,7 +399,6 @@ div.CodeMirror-dragcursors {
 .CodeMirror-hint {
   margin: 0;
   padding: 0 6px;
-  border-radius: 2px;
   white-space: pre;
   color: var(--playground-code-cursor-color, black);
   cursor: pointer;
@@ -419,7 +418,6 @@ div.CodeMirror-dragcursors {
 
 .CodeMirror-hint .hint-object-name {
   padding-right: 2em;
-  font-weight: bold;
   white-space: nowrap;
 }
 

--- a/playground-styles.css
+++ b/playground-styles.css
@@ -381,15 +381,14 @@ div.CodeMirror-dragcursors {
   list-style: none;
 
   margin: 0;
-  padding: 2px;
+  padding: 0;
 
   box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.2);
-  border-radius: 3px;
   border: 1px solid var(--playground-code-selection-background, silver);
 
   background: var(--playground-code-background, white);
   font-size: var(--playground-code-font-size, 14px);
-  font-family: monospace;
+  font-family: inherit;
 
   max-height: 20em;
   width: 600px;
@@ -399,7 +398,7 @@ div.CodeMirror-dragcursors {
 
 .CodeMirror-hint {
   margin: 0;
-  padding: 0 4px;
+  padding: 0 6px;
   border-radius: 2px;
   white-space: pre;
   color: var(--playground-code-cursor-color, black);

--- a/playground-styles.css
+++ b/playground-styles.css
@@ -392,7 +392,7 @@ div.CodeMirror-dragcursors {
 
   max-height: 20em;
   width: 600px;
-  max-width: 600px;
+  max-width: min(600px, 80vw);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Modifying the code hint styles according to discussion in https://github.com/lit/lit.dev/pull/689

- Remove padding from hintlist
- Move removed padding to items
- Remove border-radius from hintlist
- Inherit font

Subjects up for discussion:

- Should we remove the box shadow from the completion items list? Does this affect visual clarity?
- What font weight should the completion items be?