### PR TITLE
Fix language mode not set on changed documentKey

### DIFF
--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -295,7 +295,10 @@ export class PlaygroundCodeEditor extends LitElement {
             const docKey = this.documentKey ?? {};
             let docInstance = this._docCache.get(docKey);
             if (!docInstance) {
-              docInstance = new CodeMirror.Doc(this.value ?? '', this._getLanguageMode());
+              docInstance = new CodeMirror.Doc(
+                this.value ?? '',
+                this._getLanguageMode()
+              );
               this._docCache.set(docKey, docInstance);
             } else if (docInstance.getValue() !== this.value) {
               // The retrieved document instance has contents which don't

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -295,7 +295,7 @@ export class PlaygroundCodeEditor extends LitElement {
             const docKey = this.documentKey ?? {};
             let docInstance = this._docCache.get(docKey);
             if (!docInstance) {
-              docInstance = new CodeMirror.Doc(this.value ?? '');
+              docInstance = new CodeMirror.Doc(this.value ?? '', this._getLanguageMode());
               this._docCache.set(docKey, docInstance);
             } else if (docInstance.getValue() !== this.value) {
               // The retrieved document instance has contents which don't


### PR DESCRIPTION
While testing out https://github.com/lit/lit.dev/pull/689 , I noticed that the latest changes had broken the code highlighting when changing between examples in the lit.dev playground site.

I found that this bug was introduced in [this commit](https://github.com/google/playground-elements/commit/29078343774ae023df7c6bfaf6630c51cf454c50#diff-bb71b6ede2a4fde7fe6e4bf1f7b4631936108f42c47e5c3fc7bc495608a2f29cR294-R308) as when creating the new CodeMirror Doc, no languagemode was passed in.

Did some preliminary testing, modifying the built Javascript code on a local lit.dev environment and it seemed to fix the problem.

This could be attached to the code completion preview PR