### PR TITLE
Close code completions menu on blur

### DIFF
--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -706,7 +706,7 @@ export class PlaygroundCodeEditor extends LitElement {
       hint: this._completionsAsHints.bind(this),
       completeSingle: false,
       closeOnPick: true,
-      closeOnUnfocus: false,
+      closeOnUnfocus: true,
       container: this._focusContainer,
       alignWithWord: true,
     };


### PR DESCRIPTION
Code completion items menu didn't close on blur, and it was because of a dev-time setting that was forgotten on.