### PR TITLE
Fix fold region regression with document instances

### DIFF
--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -294,9 +294,11 @@ export class PlaygroundCodeEditor extends LitElement {
           case 'documentKey': {
             const docKey = this.documentKey ?? {};
             let docInstance = this._docCache.get(docKey);
+            let createdNewDoc = false;
             if (!docInstance) {
               docInstance = new CodeMirror.Doc(this.value ?? '');
               this._docCache.set(docKey, docInstance);
+              createdNewDoc = true;
             } else if (docInstance.getValue() !== this.value) {
               // The retrieved document instance has contents which don't
               // match the currently set `value`.
@@ -304,6 +306,12 @@ export class PlaygroundCodeEditor extends LitElement {
             }
             this._valueChangingFromOutside = true;
             cm.swapDoc(docInstance);
+            if (createdNewDoc) {
+              // Swapping to a document instance doesn't trigger a change event
+              // which is required for document folding. Manually fold once on
+              // document instantiation.
+              this._applyHideAndFoldRegions();
+            }
             this._valueChangingFromOutside = false;
             break;
           }

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -15,12 +15,11 @@ import type {PlaygroundCodeEditor} from '../playground-code-editor.js';
 import type {PlaygroundProject} from '../playground-project.js';
 import type {PlaygroundFileEditor} from '../playground-file-editor.js';
 
-// There is browser variability with zero width spaces. This makes tests
+// There is browser variability with zero width spaces. This helper keeps tests
 // consistent.
-function innerTextWithoutZeroWidthSpace(el?: HTMLElement | null): string {
-  return el?.innerText.replace(/\u200B/g, '') ?? '';
+function innerTextWithoutSpaces(el?: HTMLElement | null): string {
+  return el?.innerText.replace(/[\u200B\s]/g, '') ?? '';
 }
-
 suite('playground-ide', () => {
   let container: HTMLDivElement;
   let testRunning: boolean;
@@ -940,7 +939,7 @@ suite('playground-ide', () => {
       `,
       container
     );
-    const EXPECTED_FOLDED = "…\n            console.log('potato');";
+    const EXPECTED_FOLDED = "…console.log('potato');";
     const fileEditor = (await pierce(
       'playground-ide',
       'playground-file-editor'
@@ -952,7 +951,7 @@ suite('playground-ide', () => {
     )) as PlaygroundCodeEditor;
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
       EXPECTED_FOLDED
@@ -960,15 +959,15 @@ suite('playground-ide', () => {
     fileEditor.filename = 'index.html';
     await raf();
     assert.include(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
-      `<script src="hello.js"></script>`
+      `src="hello.js"></script>`
     );
     fileEditor.filename = 'hello.js';
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
       EXPECTED_FOLDED
@@ -997,7 +996,7 @@ suite('playground-ide', () => {
       `,
       container
     );
-    const EXPECTED_FOLDED = "…\n            console.log('potato');";
+    const EXPECTED_FOLDED = "…console.log('potato');";
     const fileEditor = (await pierce(
       'playground-ide',
       'playground-file-editor'
@@ -1009,7 +1008,7 @@ suite('playground-ide', () => {
     )) as PlaygroundCodeEditor;
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
       EXPECTED_FOLDED
@@ -1017,15 +1016,15 @@ suite('playground-ide', () => {
     fileEditor.filename = 'index.html';
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
-      '<body>\n…</body>'
+      '<body>…</body>'
     );
     fileEditor.filename = 'hello.js';
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
       EXPECTED_FOLDED
@@ -1054,7 +1053,7 @@ suite('playground-ide', () => {
       `,
       container
     );
-    const EXPECTED_FOLDED = "…\n            console.log('potato');";
+    const EXPECTED_FOLDED = "…console.log('potato');";
     const codemirror = (await pierce(
       'playground-ide',
       'playground-file-editor',
@@ -1065,7 +1064,7 @@ suite('playground-ide', () => {
     };
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
       EXPECTED_FOLDED
@@ -1077,16 +1076,16 @@ document.body.textContent = 'Hello JS';
 console.log('tomato');`;
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
-      "…\nconsole.log('tomato');"
+      "…console.log('tomato');"
     );
 
     codemirrorInternals._codemirror?.undo();
     await raf();
     assert.equal(
-      innerTextWithoutZeroWidthSpace(
+      innerTextWithoutSpaces(
         codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
       ),
       // This should be `EXPECTED_FOLDED`.

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -15,6 +15,12 @@ import type {PlaygroundCodeEditor} from '../playground-code-editor.js';
 import type {PlaygroundProject} from '../playground-project.js';
 import type {PlaygroundFileEditor} from '../playground-file-editor.js';
 
+// There is browser variability with zero width spaces. This makes tests
+// consistent.
+function innerTextWithoutZeroWidthSpace(el?: HTMLElement | null): string {
+  return el?.innerText.replace(/\u200B/g, '') ?? '';
+}
+
 suite('playground-ide', () => {
   let container: HTMLDivElement;
   let testRunning: boolean;
@@ -934,8 +940,7 @@ suite('playground-ide', () => {
       `,
       container
     );
-    // Folding inserts zero width spaces around the marker.
-    const EXPECTED_FOLDED = "​…​​\n            console.log('potato');";
+    const EXPECTED_FOLDED = "…\n            console.log('potato');";
     const fileEditor = (await pierce(
       'playground-ide',
       'playground-file-editor'
@@ -947,19 +952,25 @@ suite('playground-ide', () => {
     )) as PlaygroundCodeEditor;
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       EXPECTED_FOLDED
     );
     fileEditor.filename = 'index.html';
     await raf();
     assert.include(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       `<script src="hello.js"></script>`
     );
     fileEditor.filename = 'hello.js';
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       EXPECTED_FOLDED
     );
   });
@@ -986,8 +997,7 @@ suite('playground-ide', () => {
       `,
       container
     );
-    // Folding inserts zero width spaces around the marker.
-    const EXPECTED_FOLDED = "​…​​\n            console.log('potato');";
+    const EXPECTED_FOLDED = "…\n            console.log('potato');";
     const fileEditor = (await pierce(
       'playground-ide',
       'playground-file-editor'
@@ -999,19 +1009,25 @@ suite('playground-ide', () => {
     )) as PlaygroundCodeEditor;
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       EXPECTED_FOLDED
     );
     fileEditor.filename = 'index.html';
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
-      '<body>\n​…​</body>'
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
+      '<body>\n…</body>'
     );
     fileEditor.filename = 'hello.js';
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       EXPECTED_FOLDED
     );
   });
@@ -1038,8 +1054,7 @@ suite('playground-ide', () => {
       `,
       container
     );
-    // Folding inserts zero width spaces around the marker.
-    const EXPECTED_FOLDED = "​…​​\n            console.log('potato');";
+    const EXPECTED_FOLDED = "…\n            console.log('potato');";
     const codemirror = (await pierce(
       'playground-ide',
       'playground-file-editor',
@@ -1050,7 +1065,9 @@ suite('playground-ide', () => {
     };
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       EXPECTED_FOLDED
     );
     codemirror.value = `/* playground-fold */
@@ -1060,17 +1077,21 @@ document.body.textContent = 'Hello JS';
 console.log('tomato');`;
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
-      "​…​​\nconsole.log('tomato');"
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
+      "…\nconsole.log('tomato');"
     );
 
     codemirrorInternals._codemirror?.undo();
     await raf();
     assert.equal(
-      codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')?.innerText,
+      innerTextWithoutZeroWidthSpace(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
       // This should be `EXPECTED_FOLDED`.
       // Issue: https://github.com/google/playground-elements/issues/267
-      '​'
+      ''
     );
   });
 });


### PR DESCRIPTION
### Context

[The document instance commit](https://github.com/google/playground-elements/commit/29078343774ae023df7c6bfaf6630c51cf454c50#diff-bb71b6ede2a4fde7fe6e4bf1f7b4631936108f42c47e5c3fc7bc495608a2f29cR294-R308) caused a regression in code folding behavior.

The regression prevents code folding from occurring.

### Why?

Previously with a single instance, we'd attempt to code fold on every `change` event that is triggered on `setValue`. `swapDoc` doesn't trigger this code path and the folding logic never triggered.

### How was this fixed

This was fixed specifically for the document instance case. On document instance creation run the folding logic once to ensure folding occurs.

Tested with unit tests.

Also opened https://github.com/google/playground-elements/issues/267 to track an existing issue that continues to exist (although less severely) when running fold logic.