### PR TITLE
Add Ctrl+Space hotkey for triggering code completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `Ctrl-Space` hotkey for triggering interactive code completions.
 
 ## [0.15.0-pre.3] - 2022-02-16
 

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -34,6 +34,7 @@ import {
   EditorCompletionDetails,
   EditorPosition,
   EditorToken,
+  CodeEditorChangeData,
 } from './shared/worker-api.js';
 
 // TODO(aomarks) Could we upstream this to lit-element? It adds much stricter
@@ -458,6 +459,14 @@ export class PlaygroundCodeEditor extends LitElement {
               Array(cm.getOption('indentUnit') ?? 2).join(' ')
             );
           },
+          // Ctrl + Space requests code completions.
+          ['Ctrl-Space']: () => {
+            const tokenUnderCursor = this.tokenUnderCursor.string.trim();
+            this._requestCompletions({
+              isRefinement: false,
+              tokenUnderCursor,
+            });
+          },
         },
       }
     );
@@ -513,6 +522,23 @@ export class PlaygroundCodeEditor extends LitElement {
       this._completions = [];
       return;
     }
+
+    this._requestCompletions({
+      isRefinement,
+      tokenUnderCursor,
+    });
+  }
+
+  private _requestCompletions({
+    isRefinement,
+    tokenUnderCursor,
+  }: Pick<CodeEditorChangeData, 'isRefinement' | 'tokenUnderCursor'>) {
+    if (
+      this.noCompletions ||
+      !this._currentFiletypeSupportsCompletion() ||
+      !this._codemirror
+    )
+      return;
 
     const id = ++this._currentCompletionRequestId;
     const cursorIndexOnRequest = this.cursorIndex;

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -9,10 +9,11 @@ import {customElement, property, query} from 'lit/decorators.js';
 import {live} from 'lit/directives/live.js';
 
 import './playground-code-editor.js';
-import {PlaygroundProject} from './playground-project.js';
-import {PlaygroundCodeEditor} from './playground-code-editor.js';
 import {PlaygroundConnectedElement} from './playground-connected-element.js';
-import {CodeEditorChangeData} from './shared/worker-api.js';
+
+import type {PlaygroundProject} from './playground-project.js';
+import type {PlaygroundCodeEditor} from './playground-code-editor.js';
+import type {CodeEditorChangeData} from './shared/worker-api.js';
 
 /**
  * A text editor associated with a <playground-project>.

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -588,16 +588,17 @@ export class PlaygroundProject extends LitElement {
       }
     }
 
-    const searchWordIsPeriod = changeData.tokenUnderCursor === '.';
-    // In the case that the search word is a period, we don't really
+    const skipFuzzySearch =
+      changeData.tokenUnderCursor === '.' || changeData.tokenUnderCursor === '';
+    // In the case that the search word is a period or empty, we don't really
     // have any material to fuzzy find with, so we don't have need
     // for running the search results through a fuzzy search.
     // For this case, we just return the entries as completion items as is.
     let completions = [];
-    if (searchWordIsPeriod) {
+    if (skipFuzzySearch) {
       completions = completionEntriesAsEditorCompletions(
         this._completionInfo?.entries,
-        '.'
+        changeData.tokenUnderCursor
       );
     } else {
       completions = sortCompletionItems(


### PR DESCRIPTION
`Ctrl+Space` is a hotkey for triggering code completion in Vs Code. This PR adds hotkey handling.

Tested using configurator manually. Tested:

 - ctrl+space on everything, including string literals that have no completions.
 - ctrl+space on html and json file.
 - holding down ctrl+space. Triggering ctrl+space while in a hint.
    - Behavior currently triggers fresh completions and resets active selection. I think this is an ok case.

Thanks @Matsuuu for making a really easy system to add a hotkey on!
