### PR TITLE
fix: use lowercase content-type header value

### DIFF
--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -210,7 +210,7 @@ const mimeTypeToTypeEnum = (mimeType?: string) => {
   if (encodingSepIndex !== -1) {
     mimeType = mimeType.substring(0, encodingSepIndex);
   }
-  switch (mimeType.toLowerCase()) {
+  switch (mimeType) {
     // TypeScript: this is the mime-type returned by servers
     // .ts files aren't usually served to browsers, so they don't yet
     // have their own mime-type.

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -210,7 +210,7 @@ const mimeTypeToTypeEnum = (mimeType?: string) => {
   if (encodingSepIndex !== -1) {
     mimeType = mimeType.substring(0, encodingSepIndex);
   }
-  switch (mimeType) {
+  switch (mimeType.toLowerCase()) {
     // TypeScript: this is the mime-type returned by servers
     // .ts files aren't usually served to browsers, so they don't yet
     // have their own mime-type.

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -789,7 +789,8 @@ const expandProjectConfig = async (
             ...info,
             name: filename,
             content: await resp.text(),
-            contentType: resp.headers.get('Content-Type') ?? 'text/plain',
+            contentType:
+              resp.headers.get('Content-Type')?.toLowerCase() ?? 'text/plain',
           };
         })()
       );


### PR DESCRIPTION
Deployed to a server where `.ts` was being returned as `video/MP2T` instead of `video/mp2t` as required here. This particular header value is not case sensitive.

> The type, subtype, and parameter names are not case sensitive. For example, TEXT, Text, and TeXt are all equivalent. Parameter values are normally case sensitive, but certain parameters are interpreted to be case- insensitive, depending on the intended use. (For example, multipart boundaries are case-sensitive, but the "access- type" for message/External-body is not case-sensitive.)

https://www.w3.org/Protocols/rfc1341/4_Content-Type.html