### PR TITLE
Add line comment toggling hotkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Make hidden code blocks readonly to prevent accidental erasure.
 
+- Added `Ctrl+/` or `Cmd+/` hotkey for toggling line comments.
+
 ## [0.15.1] - 2022-03-16
 
 ### Changed

--- a/src/_codemirror/codemirror-bundle.js
+++ b/src/_codemirror/codemirror-bundle.js
@@ -4,8 +4,11 @@ import 'codemirror/lib/codemirror.js';
 // Hints
 import 'codemirror/addon/hint/show-hint.js';
 
-// Folding.
+// Folding
 import 'codemirror/addon/fold/foldcode.js';
+
+// Comment
+import 'codemirror/addon/comment/comment.js';
 
 // Runtime dependency for all CodeMirror modes that are generated using
 // https://github.com/codemirror/grammar-mode (i.e. the google_modes).

--- a/src/internal/codemirror.ts
+++ b/src/internal/codemirror.ts
@@ -12,6 +12,7 @@ import '../_codemirror/codemirror-bundle.js';
 import type CodeMirrorCore from 'codemirror';
 import type CoreMirrorFolding from 'codemirror/addon/fold/foldcode.js';
 import type CodeMirrorHinting from 'codemirror/addon/hint/show-hint.js';
+import type CodeMirrorComment from 'codemirror/addon/comment/comment.js';
 
 /**
  * CodeMirror function.
@@ -23,6 +24,7 @@ export const CodeMirror = (
   window as {
     CodeMirror: typeof CodeMirrorCore &
       typeof CoreMirrorFolding &
-      typeof CodeMirrorHinting;
+      typeof CodeMirrorHinting &
+      typeof CodeMirrorComment;
   }
 ).CodeMirror;

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -432,7 +432,7 @@ export class PlaygroundCodeEditor extends LitElement {
   }
 
   private _createView() {
-    const cm: Editor = CodeMirror(
+    const cm: CodeMirror.Editor = CodeMirror(
       (dom) => {
         this._cmDom = dom;
         this._resizing = true;

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -432,7 +432,7 @@ export class PlaygroundCodeEditor extends LitElement {
   }
 
   private _createView() {
-    const cm = CodeMirror(
+    const cm: Editor = CodeMirror(
       (dom) => {
         this._cmDom = dom;
         this._resizing = true;
@@ -472,6 +472,8 @@ export class PlaygroundCodeEditor extends LitElement {
               tokenUnderCursor,
             });
           },
+          ['Ctrl-/']: () => cm.toggleComment(),
+          ['Cmd-/']: () => cm.toggleComment(),
         },
       }
     );

--- a/src/test/playground-code-editor_test.ts
+++ b/src/test/playground-code-editor_test.ts
@@ -366,8 +366,10 @@ suite('playground-code-editor', () => {
       await sendKeys({
         up: 'Control',
       });
+      await raf();
 
       assert.include(
+        // There isn't a focusContainer when the editor is in readonly mode.
         editor.shadowRoot!.querySelector<HTMLDivElement>('div')!.innerText,
         'const g = 3;'
       );

--- a/src/test/playground-code-editor_test.ts
+++ b/src/test/playground-code-editor_test.ts
@@ -7,6 +7,7 @@
 import {assert} from '@esm-bundle/chai';
 import '../playground-code-editor.js';
 import {PlaygroundCodeEditor} from '../playground-code-editor.js';
+import { sendKeys } from '@web/test-runner-commands';
 
 const raf = async () => new Promise((r) => requestAnimationFrame(r));
 
@@ -59,6 +60,28 @@ suite('playground-code-editor', () => {
       };
       editorInternals._codemirror!.setValue('bar');
     });
+  });
+
+  test('supports comment toggling', async () => {
+    const editor = document.createElement('playground-code-editor');
+    editor.value = 'foo';
+    container.appendChild(editor);
+    await editor.updateComplete;
+
+    editor.focus();
+    await raf();
+    await sendKeys({
+      down: 'Control',
+    });
+    await sendKeys({
+      press: 'Slash',
+    });
+    sendKeys({
+      up: 'Control',
+    });
+    await raf();
+
+    assert.include(editor.shadowRoot!.innerHTML, '// foo');
   });
 
   suite('history', () => {

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -887,12 +887,10 @@ suite('playground-ide', () => {
     <script src="hello.js">&lt;/script>
     <p>Add this</p>
     </body>`);
-    // assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
     await raf();
 
     fileEditor.filename = 'hello.js';
     await raf();
-    // assert.equal(editorInternals._codemirror!.getHistory()?.done.length, 3);
     assert.include(editorInternals._codemirror!.getValue(), `'Hello 2'`);
 
     for (let i = 0; i < 6; i++) {


### PR DESCRIPTION
Resolves part of https://github.com/google/playground-elements/issues/148

### Context

Add the `Ctrl+/` and `Cmd+/` hotkey to toggle line comments (such that it is supported for either Mac/Linux/Windows keyboard layout).

This was implemented by adding comment support via CodeMirror plugin. I omitted supporting the block comment as it's much more difficult to determine if it's toggling.

### Testing

Manually tested (TypeScript) in the configurator checking that it is possible to select multiple lines and toggle them.
Also manually tested that undo works.

Unit tested:

 - Sending the hotkey in the automated tests and commenting `ts`, `js`, `css`, `html`.
 - `readonly` playground-code-editor will not toggle.
