### PR TITLE
Add readme documentation for additional keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `Ctrl+/` or `Cmd+/` hotkey for toggling line comments.
 
+- Added keyboard shortcut documentation to the playground-code-editor README.
+
 ## [0.15.1] - 2022-03-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ with the following:
 | ----------------------- | -------------------------------------- |
 | `Ctrl + Space`          | Trigger code completion when supported |
 | `Ctrl + /` or `Cmd + /` | Toggle line comments                   |
-| `ESC`                   | Blur or de-focus the code editor       |
+| `ESC`                   | De-focus the code editor               |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -781,6 +781,18 @@ A pure text editor based on CodeMirror with syntax highlighting for HTML, CSS, J
 | --------- | ------------------------------------ |
 | `changed` | User made an edit to the active file |
 
+### Keyboard shortcuts
+
+The playground code editor extends the
+[CodeMirror default keyboard shortcuts](https://github.com/codemirror/CodeMirror/blob/master/src/input/keymap.js)
+with the following:
+
+| Keyboard shortcut       | Description                            |
+| ----------------------- | -------------------------------------- |
+| `Ctrl + Space`          | Trigger code completion when supported |
+| `Ctrl + /` or `Cmd + /` | Toggle line comments                   |
+| `ESC`                   | Blur or de-focus the code editor       |
+
 ---
 
 ## `<playground-preview>`


### PR DESCRIPTION
Fixes https://github.com/google/playground-elements/issues/285

Documentation only change.

Adds a README section documenting additional keyboard shortcuts we've added to the playground-editor.