### PR TITLE
fix flaky test

### DIFF
--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -684,8 +684,9 @@ suite('playground-ide', () => {
       'playground-project'
     )) as PlaygroundProject;
 
-    await project.save();
-    await waitForIframeLoad(iframe);
+    const savePromise = project.save();
+    const reloadPromise = waitForIframeLoad(iframe);
+    await Promise.all([savePromise, reloadPromise]);
 
     const newIframe = (await pierce(
       'playground-ide',

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -684,8 +684,6 @@ suite('playground-ide', () => {
       'playground-project'
     )) as PlaygroundProject;
 
-    const savePromise = project.save();
-    const reloadPromise = waitForIframeLoad(iframe);
     await Promise.all([waitForIframeLoad(iframe), project.save()]);
 
     const newIframe = (await pierce(


### PR DESCRIPTION
This test flakes and my guess is that it will do so awaiting the iframe load which just watches for the `load` event. It seems that the `save` method will do a compilation and then trigger a reload of the iframe within it. My guess is that we are adding the iframe load event listener too late in some flaky cases.