### PR TITLE
Fix test that only fails when version is bumped.

### DIFF
--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -653,7 +653,7 @@ suite('playground-ide', () => {
   test('reloading preview does not create a new iframe element', async () => {
     render(
       html`
-        <playground-ide>
+        <playground-ide sandbox-base-url="/">
           <script type="sample/html" filename="index.html">
             <body>
               <p>Hello HTML 1</p>
@@ -663,6 +663,7 @@ suite('playground-ide', () => {
       `,
       container
     );
+
     const preview = (await pierce(
       'playground-ide',
       'playground-preview'


### PR DESCRIPTION
### Context

This test would consistently fail on release PRs.

### Why and fix

By default - for security - the playground preview pulls itself from unpkg and uses a separate origin. Docs pulled directly from source code:

```
   * Base URL for script execution sandbox.
   *
   * It is highly advised to change this property to a URL on a separate origin
   * which has no privileges to perform sensitive actions or access sensitive
   * data. This is because this element will execute arbitrary JavaScript, and
   * does not have the ability to sanitize or sandbox it.
   *
   * This URL must host the following files from the playground-elements
   * package:
   *   1. playground-service-worker.js
   *   2. playground-service-worker-proxy.html
   *
   * Defaults to the directory containing the script that defines this element
   * on the same origin (typically something like
   * "/node_modules/playground-elements/").
```

However, the default url uses the local `npmVersion`, i.e.:

```
sandboxBaseUrl = `https://unpkg.com/playground-elements@${npmVersion}/`;
```

When the `npmVersion` is bumped - for example in a release PR, the test tries to fetch from a version that isn't published and the resulting 404 causes the test to fail.

Then once the new library version is published, the CI is green again, because that new version is published to unpkg.


### Testing

This is a test only change. Tested locally and through github actions. Changed the npmVersion locally to a version that isn't on unpkg for testing.

Thank you to @aomarks for diagnosing root cause.
