### PR TITLE
Fix and cleanup fold and hide logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed the hiding of comments that surround a fold/hide code block from
+  creating invisible readonly regions.
+
+- Refactored fold/hide marker logic so it doesn't add document history when
+  clearing the prior fold/hide markers.
+
 ## [0.15.2] - 2022-03-24
 
 ### Added

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -859,10 +859,10 @@ export class PlaygroundCodeEditor extends LitElement {
       this._hideOrFoldRegionsActive = true;
     };
 
-    const hide = (fromIdx: number, toIdx: number) => {
+    const hide = (fromIdx: number, toIdx: number, readOnly: boolean) => {
       doc.markText(doc.posFromIndex(fromIdx), doc.posFromIndex(toIdx), {
         collapsed: true,
-        readOnly: true,
+        readOnly,
       });
       this._hideOrFoldRegionsActive = true;
     };
@@ -875,7 +875,7 @@ export class PlaygroundCodeEditor extends LitElement {
       }
 
       const openerEnd = openerStart + opener.length;
-      hide(openerStart, openerEnd);
+      hide(openerStart, openerEnd, false);
 
       const contentStart = openerEnd;
       let contentEnd;
@@ -883,7 +883,7 @@ export class PlaygroundCodeEditor extends LitElement {
         contentEnd = contentStart + content.length;
         const closerStart = contentEnd;
         const closerEnd = contentEnd + closer.length;
-        hide(closerStart, closerEnd);
+        hide(closerStart, closerEnd, false);
       } else {
         // No matching end comment. Include the entire rest of the file.
         contentEnd = value.length;
@@ -893,7 +893,7 @@ export class PlaygroundCodeEditor extends LitElement {
         if (kind === 'fold') {
           fold(contentStart, contentEnd);
         } else if (kind === 'hide') {
-          hide(contentStart, contentEnd);
+          hide(contentStart, contentEnd, true);
         }
       }
     }

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -1076,8 +1076,6 @@ suite('playground-ide', () => {
     );
   });
 
-  // Test currently reproduces a bug.
-  // Issue: https://github.com/google/playground-elements/issues/267
   test('code remains folded on value change and undo', async () => {
     render(
       html`
@@ -1129,15 +1127,12 @@ console.log('tomato');`;
 
     codemirrorInternals._codemirror?.undo();
     await raf();
-    /*
-     * Comment out failing test for now. To be fixed in a future PR.
-     * Related issue: https://github.com/google/playground-elements/issues/267
-     * assert.equal(
-     * innerTextWithoutSpaces(
-     *    codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
-     *  ),
-     *  EXPECTED_FOLDED
-     *);
-     */
+
+    assert.equal(
+      innerTextWithoutSpaces(
+        codemirror?.shadowRoot?.querySelector<HTMLDivElement>('*')
+      ),
+      EXPECTED_FOLDED
+    );
   });
 });


### PR DESCRIPTION
Fixes readonly characters when code folding (commit 1).
Fixes https://github.com/google/playground-elements/issues/267 (commit 2).

Note to reviewer:
 - Commit 1 fixes the `hide` folding of marker comments so they're not readonly.
 - Commit 2 replaces the TextMarker clearing logic such that it doesn't add history.
 - Commit 3 is changelog.

### Context

Playground elements has a great [Hiding & folding](https://github.com/google/playground-elements#hiding--folding) feature that uses comments to mark regions of code that can be folded or hidden. Regardless of whether hiding or folding, the comment markers themselves are always hidden. E.g.

```ts
/* playground-fold */
console.log('hi');
/* playground-fold-end */
```

Results in CodeMirror markers which can be visualized as:

```
hide(/* playground-fold */)
fold(console.log('hi');)
hide(/* playground-fold-end */)
```

A recent change causes all `hide` regions to be readonly. In the `fold` case this results in the folded region still being editable, but the comment markers creating invisible markers that cannot be deleted.

### Fix

Make the comment markers not readonly. Thus when used as part of either folding of hiding they can be deleted. The deletion of a hidden region is atomic so the marker can be completely deleted by a user in one keystroke. Prior behavior was that the delete key would not delete the comment marker and cursor would get stuck (if pressing delete multiple times).

### Investigation that lead to second commit

I also investigated trying to clear the hide/fold comments from the document value, however any change to the codeMirror value resulted in history pollution.
While investigating this I also inspected the way we reset all the text markers by clearing and resetting the document contents.

I noticed the marker clearing technique also added history state by pushing an empty string onto the history. By refactoring it to clear the markers we no longer pollute history and can simplify some state variables.

### Testing

I tested both folding and hiding in the configurator, and also fixed the broken unit test.
