### PR TITLE
Fix README typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Refactored fold/hide marker logic so it doesn't add document history when
   clearing the prior fold/hide markers.
 
+- Fix typo and incorrectly documented event name in README. `changed` event
+  should instead be `change`.
+
 ## [0.15.2] - 2022-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -777,9 +777,9 @@ A pure text editor based on CodeMirror with syntax highlighting for HTML, CSS, J
 
 ### Events
 
-| Event     | Description                          |
-| --------- | ------------------------------------ |
-| `changed` | User made an edit to the active file |
+| Event    | Description                          |
+| -------- | ------------------------------------ |
+| `change` | User made an edit to the active file |
 
 ### Keyboard shortcuts
 
@@ -808,7 +808,7 @@ with the following:
 
 ---
 
-## `<playground-file-system-controls`
+## `<playground-file-system-controls>`
 
 Floating controls for adding, deleting, and renaming files.
 


### PR DESCRIPTION
Fixes two typos identified by https://github.com/google/playground-elements/issues/296


Does this need changelog as it's tiny and instantly benefits the repo README?

Thank you