### PR TITLE
Add ability to select a file in project.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+<!-- ## Unreleased -->
+### Added
+
+- Add the ability to select a file by setting `selected: true` in a project
+  config, or by setting the `selected` attribute on slotted children.
+
 ## [0.15.3] - 2022-03-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 
 <!-- ## Unreleased -->
+
 ### Added
 
 - Add the ability to select a file by setting `selected: true` in a project

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ your `<playground-ide>` or `<playground-project>`, using the following attribute
 | `filename`            | Required filename.                                                                                                    |
 | `label`               | Optional label for display in `playground-tab-bar`. If omitted, the filename is displayed.                            |
 | `hidden`              | If present, the file won't be visible in `playground-tab-bar`.                                                        |
+| `selected`            | If present, this file's tab will be selected when the project is loaded. Only one file should have this attribute.    |
 | `preserve-whitespace` | Disable the default behavior where leading whitespace that is common to all lines is removed.                         |
 
 Be sure to escape closing `</script>` tags within your source as `&lt;script>`.
@@ -210,6 +211,7 @@ Set the `project-src` attribute or `projectSrc` property to a JSON file with for
 | `files.contentType` | Optional MIME type of the file. If omitted, type is taken from either the `fetch` response `Content-Type` header, or inferred from the filename extension when `content` is set. |
 | `files.label`       | Optional label for display in `playground-tab-bar`. If omitted, the filename is displayed.                                                                                       |
 | `files.hidden`      | If `true`, the file won't be visible in `playground-tab-bar`.                                                                                                                    |
+| `files.selected`    | If `true`, this file's tab will be selected when the project is loaded. Only one file should have this field set.                                                                |
 | `extends`           | Optional URL to another JSON config file to extend from. Configs are deeply merged. URLs are interpreted relative to the URL of each extendee config.                            |
 
 ```html

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -353,7 +353,9 @@ export class PlaygroundProject extends LitElement {
     this._pristineFiles =
       this._files && JSON.parse(JSON.stringify(this._files));
     this._modified = false;
-    this.dispatchEvent(new CustomEvent('filesChanged'));
+    this.dispatchEvent(
+      new CustomEvent('filesChanged', {detail: {projectLoaded: true}})
+    );
     this.save();
   }
 

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -411,6 +411,7 @@ export class PlaygroundProject extends LitElement {
         }
         // Note "" is an invalid label.
         const label = s.getAttribute('label') || undefined;
+        const selected = s.hasAttribute('selected');
         const contentType = typeEnumToMimeType(fileType);
         files.push({
           name,
@@ -418,6 +419,7 @@ export class PlaygroundProject extends LitElement {
           hidden: s.hasAttribute('hidden'),
           content,
           contentType,
+          selected,
         });
       }
     }

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -51,6 +51,20 @@ const generateUniqueSessionId = (): string => {
   return sessionId;
 };
 
+declare global {
+  interface HTMLElementEventMap {
+    filesChanged: FilesChangedEvent;
+  }
+}
+
+export class FilesChangedEvent extends Event {
+  projectLoaded: boolean;
+  constructor(projectLoaded = false) {
+    super('filesChanged');
+    this.projectLoaded = projectLoaded;
+  }
+}
+
 /**
  * Coordinates <playground-file-editor> and <playground-preview> elements.
  */
@@ -353,9 +367,7 @@ export class PlaygroundProject extends LitElement {
     this._pristineFiles =
       this._files && JSON.parse(JSON.stringify(this._files));
     this._modified = false;
-    this.dispatchEvent(
-      new CustomEvent('filesChanged', {detail: {projectLoaded: true}})
-    );
+    this.dispatchEvent(new FilesChangedEvent(true));
     this.save();
   }
 
@@ -688,7 +700,7 @@ export class PlaygroundProject extends LitElement {
     }
     this._modified = undefined;
     this.requestUpdate();
-    this.dispatchEvent(new CustomEvent('filesChanged'));
+    this.dispatchEvent(new FilesChangedEvent());
     this.save();
   }
 
@@ -702,7 +714,7 @@ export class PlaygroundProject extends LitElement {
     }
     this._files = [...this._files.slice(0, idx), ...this._files.slice(idx + 1)];
     this._modified = undefined;
-    this.dispatchEvent(new CustomEvent('filesChanged'));
+    this.dispatchEvent(new FilesChangedEvent());
     this.save();
   }
 
@@ -722,7 +734,7 @@ export class PlaygroundProject extends LitElement {
     file.contentType = typeFromFilename(newName);
     this._files = [...this._files];
     this._modified = undefined;
-    this.dispatchEvent(new CustomEvent('filesChanged'));
+    this.dispatchEvent(new FilesChangedEvent());
     this.save();
   }
 }

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -225,7 +225,18 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     `;
   }
 
-  private _onProjectFilesChanged = () => {
+  private _onProjectFilesChanged = (event?: Event) => {
+    const newProjectLoaded = (
+      event as unknown as {detail?: {projectLoaded: boolean}}
+    )?.detail?.projectLoaded;
+    if (newProjectLoaded) {
+      const fileToSelect = this._visibleFiles.find(
+        (file) => file.selected
+      )?.name;
+      if (fileToSelect !== undefined) {
+        this._activeFileName = fileToSelect;
+      }
+    }
     this._setNewActiveFile();
     this.requestUpdate();
   };

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -146,7 +146,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
         );
       }
       if (this._project) {
-        this._onProjectFilesChanged();
+        this._handleFilesChanged(true);
         this._project.addEventListener(
           'filesChanged',
           this._onProjectFilesChanged
@@ -229,6 +229,10 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     const newProjectLoaded = (
       event as unknown as {detail?: {projectLoaded: boolean}}
     )?.detail?.projectLoaded;
+    this._handleFilesChanged(newProjectLoaded);
+  };
+
+  private _handleFilesChanged(newProjectLoaded = false) {
     if (newProjectLoaded) {
       const fileToSelect = this._visibleFiles.find(
         (file) => file.selected
@@ -239,7 +243,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     }
     this._setNewActiveFile();
     this.requestUpdate();
-  };
+  }
 
   private _onTabchange(
     event: CustomEvent<{

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -17,7 +17,10 @@ import {PlaygroundConnectedElement} from './playground-connected-element.js';
 
 import type {PlaygroundFileEditor} from './playground-file-editor.js';
 import type {PlaygroundFileSystemControls} from './playground-file-system-controls.js';
-import type {PlaygroundProject} from './playground-project.js';
+import type {
+  FilesChangedEvent,
+  PlaygroundProject,
+} from './playground-project.js';
 import type {PlaygroundInternalTab} from './internal/tab.js';
 
 /**
@@ -225,11 +228,8 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     `;
   }
 
-  private _onProjectFilesChanged = (event?: Event) => {
-    const newProjectLoaded = (
-      event as unknown as {detail?: {projectLoaded: boolean}}
-    )?.detail?.projectLoaded;
-    this._handleFilesChanged(newProjectLoaded);
+  private _onProjectFilesChanged = (event: FilesChangedEvent) => {
+    this._handleFilesChanged(event.projectLoaded);
   };
 
   private _handleFilesChanged(newProjectLoaded = false) {

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -179,6 +179,8 @@ export interface FileOptions {
   label?: string;
   /** Don't display in tab bar. */
   hidden?: boolean;
+  /** Whether the file should be selected when loaded */
+  selected?: boolean;
 }
 
 export interface ProjectManifest {

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -163,6 +163,8 @@ export interface SampleFile {
   contentType?: string;
   /** Don't display in tab bar. */
   hidden?: boolean;
+  /** Whether the file should be selected when loaded */
+  selected?: boolean;
 }
 
 export interface FileOptions {

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -1262,5 +1262,4 @@ console.log('tomato');`;
     );
     await assertTabSelected('b.html');
   });
-
 });

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -96,6 +96,25 @@ suite('playground-ide', () => {
     });
   };
 
+  const assertTabSelected = async (filename: string) => {
+    await new Promise((r) => setTimeout(r));
+    const tabBar = await pierce('playground-ide', 'playground-tab-bar');
+    while (testRunning) {
+      const selectedTab = tabBar.shadowRoot!.querySelector(
+        'playground-internal-tab[active]'
+      );
+      if (selectedTab) {
+        assert.include(
+          selectedTab.textContent?.trim(),
+          filename,
+          `Selected tab did not contain '${filename}')`
+        );
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  };
+
   test('renders HTML', async () => {
     render(
       html`
@@ -1135,4 +1154,113 @@ console.log('tomato');`;
       EXPECTED_FOLDED
     );
   });
+
+  test('focuses file with selected flag, from config', async () => {
+    const ide = document.createElement('playground-ide')!;
+    ide.sandboxBaseUrl = '/';
+    container.appendChild(ide);
+    // Start with a.html selected
+    ide.config = {
+      files: {
+        'index.html': {
+          content: 'index',
+        },
+        'a.html': {
+          content: 'A',
+          selected: true,
+        },
+        'b.html': {
+          content: 'B',
+        },
+      },
+    };
+    await assertTabSelected('a.html');
+    // Change to b.html selected
+    ide.config = {
+      files: {
+        'index.html': {
+          content: 'index',
+        },
+        'a.html': {
+          content: 'A',
+        },
+        'b.html': {
+          content: 'B',
+          selected: true,
+        },
+      },
+    };
+    await assertTabSelected('b.html');
+    // Nothing selected; should stay on b.html
+    ide.config = {
+      files: {
+        'index.html': {
+          content: 'index',
+        },
+        'b.html': {
+          content: 'B',
+        },
+        'a.html': {
+          content: 'A',
+        },
+      },
+    };
+    await assertTabSelected('b.html');
+  });
+
+  test('focuses file with selected flag, from slots', async () => {
+    // Start with a.html selected
+    render(
+      html`
+        <playground-ide sandbox-base-url="/">
+          <script type="sample/html" filename="index.html">
+            index
+          </script>
+          <script type="sample/html" filename="a.html" selected>
+            A
+          </script>
+          <script type="sample/html" filename="b.html">
+            B
+          </script>
+        </playground-ide>
+      `,
+      container
+    );
+    const ide = container.firstElementChild as PlaygroundIde;
+    await assertTabSelected('a.html');
+    // Change to b.html selected
+    ide.textContent = '';
+    render(
+      html`
+        <script type="sample/html" filename="index.html">
+          index
+        </script>
+        <script type="sample/html" filename="a.html">
+          A
+        </script>
+        <script type="sample/html" filename="b.html" selected>
+          B
+        </script>
+      `,
+      ide
+    );
+    await assertTabSelected('b.html');
+    // Nothing selected; should stay on b.html
+    render(
+      html`
+        <script type="sample/html" filename="index.html">
+          index
+        </script>
+        <script type="sample/html" filename="a.html">
+          A
+        </script>
+        <script type="sample/html" filename="b.html">
+          B
+        </script>
+      `,
+      ide
+    );
+    await assertTabSelected('b.html');
+  });
+
 });

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -37,15 +37,15 @@ export default {
   nodeResolve: true,
   browsers: [
     playwrightLauncher({product: 'chromium'}),
-    playwrightLauncher({product: 'webkit'}),
-    // Playwright Firefox does not currently work with service workers, see
-    // https://github.com/microsoft/playwright/issues/7288.
-    //
-    // Also note we can't use Puppeteer for both Chromium and Firefox, because
-    // only one or the other can be installed at once (see our "postinstall" NPM
-    // script). See
-    // https://modern-web.dev/docs/test-runner/browser-launchers/puppeteer/.
-    puppeteerLauncher({launchOptions: {product: 'firefox'}}),
+    // playwrightLauncher({product: 'webkit'}),
+    // // Playwright Firefox does not currently work with service workers, see
+    // // https://github.com/microsoft/playwright/issues/7288.
+    // //
+    // // Also note we can't use Puppeteer for both Chromium and Firefox, because
+    // // only one or the other can be installed at once (see our "postinstall" NPM
+    // // script). See
+    // // https://modern-web.dev/docs/test-runner/browser-launchers/puppeteer/.
+    // puppeteerLauncher({launchOptions: {product: 'firefox'}}),
   ],
   browserStartTimeout: 30000, // default 30000
   testsStartTimeout: 20000, // default 10000

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -37,15 +37,15 @@ export default {
   nodeResolve: true,
   browsers: [
     playwrightLauncher({product: 'chromium'}),
-    // playwrightLauncher({product: 'webkit'}),
-    // // Playwright Firefox does not currently work with service workers, see
-    // // https://github.com/microsoft/playwright/issues/7288.
-    // //
-    // // Also note we can't use Puppeteer for both Chromium and Firefox, because
-    // // only one or the other can be installed at once (see our "postinstall" NPM
-    // // script). See
-    // // https://modern-web.dev/docs/test-runner/browser-launchers/puppeteer/.
-    // puppeteerLauncher({launchOptions: {product: 'firefox'}}),
+    playwrightLauncher({product: 'webkit'}),
+    // Playwright Firefox does not currently work with service workers, see
+    // https://github.com/microsoft/playwright/issues/7288.
+    //
+    // Also note we can't use Puppeteer for both Chromium and Firefox, because
+    // only one or the other can be installed at once (see our "postinstall" NPM
+    // script). See
+    // https://modern-web.dev/docs/test-runner/browser-launchers/puppeteer/.
+    puppeteerLauncher({launchOptions: {product: 'firefox'}}),
   ],
   browserStartTimeout: 30000, // default 30000
   testsStartTimeout: 20000, // default 10000


### PR DESCRIPTION
The selected file in the file tabs is selected based on the selected file in the project config only when loading a new project.

Fixes https://github.com/google/playground-elements/issues/303