### PR TITLE
Fix typo in README and fix changelog entry location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added keyboard shortcut documentation to the playground-code-editor README.
 
-
 ## [0.15.1] - 2022-03-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix typo in README. Add missing forward slash in escaped script tag.
+
+### Added
+
+- Added `lineWrapping` property (`line-wrapping` attribute) to
+  `<playground-code-editor>`, `<playground-file-editor>` and `<playground-ide>`
+  which when enabled wraps long lines, otherwise the editor will scroll. Off by
+  default.
 
 ## [0.15.4] - 2022-04-05
 
@@ -49,10 +60,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added keyboard shortcut documentation to the playground-code-editor README.
 
-- Added `lineWrapping` property (`line-wrapping` attribute) to
-  `<playground-code-editor>`, `<playground-file-editor>` and `<playground-ide>`
-  which when enabled wraps long lines, otherwise the editor will scroll. Off by
-  default.
 
 ## [0.15.1] - 2022-03-16
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ your `<playground-ide>` or `<playground-project>`, using the following attribute
 | `selected`            | If present, this file's tab will be selected when the project is loaded. Only one file should have this attribute.    |
 | `preserve-whitespace` | Disable the default behavior where leading whitespace that is common to all lines is removed.                         |
 
-Be sure to escape closing `</script>` tags within your source as `&lt;script>`.
+Be sure to escape closing `</script>` tags within your source as `&lt;/script>`.
 
 ```html
 <playground-project>


### PR DESCRIPTION
This is a small PR with two changes.

1. Typo in README with script escaping.
2. The lineWrapping PR took a couple releases before merging, so the CHANGELOG entry is not in the correct place. Moved line wrapping change to the unreleased section.

This is a documentation only PR.