### PR TITLE
Allow consumer to use any/latest version mwc-elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,12 +85,12 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "@material/mwc-button": "^0.25.1",
-    "@material/mwc-icon-button": "^0.25.1",
-    "@material/mwc-linear-progress": "^0.25.1",
-    "@material/mwc-list": "^0.25.1",
-    "@material/mwc-menu": "^0.25.1",
-    "@material/mwc-textfield": "^0.25.1",
+    "@material/mwc-button": "*",
+    "@material/mwc-icon-button": "*",
+    "@material/mwc-linear-progress": "*",
+    "@material/mwc-list": "*",
+    "@material/mwc-menu": "*",
+    "@material/mwc-textfield": "*",
     "@types/codemirror": "^5.60.0",
     "comlink": "=4.3.1",
     "fuse.js": "^6.4.6",


### PR DESCRIPTION
Fixes the famous:

```my-app.ts:118 DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "mwc-ripple" has already been used with this registry```