### PR TITLE
[infra] Update wireit and fix output config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "semver": "^7.3.5",
         "tsc-watch": "^4.2.3",
         "typescript": "^4.4.3",
-        "wireit": "^0.5.0"
+        "wireit": "^0.7.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -10744,9 +10744,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.5.0.tgz",
-      "integrity": "sha512-WaUBjf6Uglipf3q5vNoLsryofZcGq6CxG5vbZsyaqcL2j+/T3+lc/NlEjXMTAWmb8a3MvpVhX3NUk8S04clpRw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
+      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -19571,9 +19571,9 @@
       }
     },
     "wireit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.5.0.tgz",
-      "integrity": "sha512-WaUBjf6Uglipf3q5vNoLsryofZcGq6CxG5vbZsyaqcL2j+/T3+lc/NlEjXMTAWmb8a3MvpVhX3NUk8S04clpRw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
+      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:playwright": "wireit",
     "lint": "wireit",
     "lint:eslint": "wireit",
-    "serve": "npm run build && (npm run build watch & web-dev-server --node-resolve --watch --open=configurator/)",
+    "serve": "npm run build && (npm run build --watch & web-dev-server --node-resolve --watch --open=configurator/)",
     "format": "prettier --write .",
     "lint:format": "prettier --check ."
   },
@@ -282,7 +282,7 @@
     "semver": "^7.3.5",
     "tsc-watch": "^4.2.3",
     "typescript": "^4.4.3",
-    "wireit": "^0.5.0"
+    "wireit": "^0.7.1"
   },
   "dependencies": {
     "@material/mwc-button": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
       "output": [
         "index-*.{js,d.ts,d.ts.map}",
         "playground-*.{js,d.ts,d.ts.map}",
+        "!playground-service-worker-proxy.html",
+        "!playground-service-worker.js",
+        "!playground-typescript-worker.js",
         "service-worker/**",
         "typescript-worker/**",
         "internal/**",
@@ -72,8 +75,10 @@
         "shared/**",
         "test/**",
         "themes/**",
+        "!themes/**/*.css",
         "configurator/**/*.{js,d.ts,d.ts.map}",
         "!configurator/playground-service-worker.js",
+        "!configurator/deploy/**",
         ".tsbuildinfo"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "service-worker/**",
         "typescript-worker/**",
         "internal/**",
+        "!internal/typescript.js",
         "shared/**",
         "test/**",
         "themes/**",


### PR DESCRIPTION
I noticed the `build` command was failing due to overlapping output of `internal/typescript.js` which was getting erroneously cleaned out.

Updating `wireit` to the latest version with output modified detection surfaced additional overlaps.