### PR TITLE
Modifications for Google import compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": "./tsconfig.json"
   },
   "plugins": ["@typescript-eslint", "no-only-tests", "import"],
   "rules": {
@@ -15,13 +16,51 @@
     "import/extensions": ["error", "always"],
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-non-null-assertion": "off"
+    "@typescript-eslint/no-non-null-assertion": "off",
+    // Google internally requires that floating promises are annotated with a
+    // special function. We use eslint-enable and eslint-disable comments for
+    // this rule to identify these spots for automated transform on import.
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "overrides": [
     {
       "files": ["src/playground-styles.ts"],
       "rules": {
         "no-var": "off"
+      }
+    },
+    {
+      "files": ["src/typescript-worker/**"],
+      "parserOptions": {
+        "project": "./src/typescript-worker/tsconfig.json"
+      }
+    },
+    {
+      "files": ["src/service-worker/**"],
+      "parserOptions": {
+        "project": "./src/service-worker/tsconfig.json"
+      }
+    },
+    {
+      "files": ["src/shared/**"],
+      "parserOptions": {
+        "project": "./src/shared/tsconfig.json"
+      }
+    },
+    {
+      // These files aren't imported into Google so we don't care about floating
+      // promises.
+      "files": [
+        "scripts/**",
+        "playwright.config.ts",
+        "src/configurator/**",
+        "src/test/**"
+      ],
+      "parserOptions": {
+        "project": null
+      },
+      "rules": {
+        "@typescript-eslint/no-floating-promises": "off"
       }
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Removed `vscode-languageserver` dependency.
+- TypeScript version upgraded from `4.4.4` to `4.7.4`.
 
 ## [0.16.3] - 2022-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Removed `vscode-languageserver` dependency.
 
 ## [0.16.3] - 2022-08-02
 

--- a/configurator/project/my-element.ts
+++ b/configurator/project/my-element.ts
@@ -6,7 +6,7 @@ export class MyElement extends LitElement {
   @property()
   greet = 'nobody';
 
-  render() {
+  override render() {
     return html`<p>Hello <b>${this.greet}</b>!</p>`;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "semver": "^7.3.5",
         "tsc-watch": "^4.2.3",
-        "typescript": "^4.4.3",
+        "typescript": "~4.7.4",
         "vscode-languageserver-protocol": "^3.17.2",
         "wireit": "^0.7.1"
       }
@@ -10444,9 +10444,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19324,9 +19324,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,7 @@
         "comlink": "=4.3.1",
         "fuse.js": "^6.4.6",
         "lit": "^2.0.0",
-        "tslib": "^2.0.3",
-        "vscode-languageserver": "^7.0.0"
+        "tslib": "^2.0.3"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.1.5",
@@ -55,6 +54,7 @@
         "semver": "^7.3.5",
         "tsc-watch": "^4.2.3",
         "typescript": "^4.4.3",
+        "vscode-languageserver-protocol": "^3.17.2",
         "wireit": "^0.7.1"
       }
     },
@@ -10631,37 +10631,29 @@
       "dev": true
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "dev": true,
       "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.16.0"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "dev": true,
       "dependencies": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -19482,31 +19474,26 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
-    },
-    "vscode-languageserver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-      "requires": {
-        "vscode-languageserver-protocol": "3.16.0"
-      }
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "dev": true
     },
     "vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "dev": true,
       "requires": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "semver": "^7.3.5",
     "tsc-watch": "^4.2.3",
-    "typescript": "^4.4.3",
+    "typescript": "~4.7.4",
     "vscode-languageserver-protocol": "^3.17.2",
     "wireit": "^0.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
     "semver": "^7.3.5",
     "tsc-watch": "^4.2.3",
     "typescript": "^4.4.3",
+    "vscode-languageserver-protocol": "^3.17.2",
     "wireit": "^0.7.1"
   },
   "dependencies": {
@@ -300,7 +301,6 @@
     "comlink": "=4.3.1",
     "fuse.js": "^6.4.6",
     "lit": "^2.0.0",
-    "tslib": "^2.0.3",
-    "vscode-languageserver": "^7.0.0"
+    "tslib": "^2.0.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import type {PlaywrightTestConfig} from '@playwright/test';
+import {PlaywrightTestConfig} from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   testDir: 'src/test/playwright',

--- a/src/configurator/playground-configurator.ts
+++ b/src/configurator/playground-configurator.ts
@@ -33,7 +33,7 @@ import {tokens} from './highlight-tokens.js';
  */
 @customElement('playground-configurator')
 export class PlaygroundConfigurator extends LitElement {
-  static styles = [
+  static override styles = [
     ...themeStyles,
     css`
       :host {
@@ -171,7 +171,7 @@ export class PlaygroundConfigurator extends LitElement {
   @query('playground-ide')
   private _ide!: PlaygroundIde;
 
-  connectedCallback() {
+  override connectedCallback() {
     super.connectedCallback();
     this.readUrlParams(new URL(document.location.href).searchParams);
   }
@@ -297,7 +297,7 @@ export class PlaygroundConfigurator extends LitElement {
     history.replaceState(null, '', '?' + params.toString());
   }
 
-  render() {
+  override render() {
     return html`
       <style>
         ${this.cssText}

--- a/src/configurator/playground-theme-detector.ts
+++ b/src/configurator/playground-theme-detector.ts
@@ -12,7 +12,7 @@ import {tokens} from './highlight-tokens.js';
 
 @customElement('playground-theme-detector')
 export class PlaygroundThemeDetector extends LitElement {
-  static styles = css`
+  static override styles = css`
     ol {
       padding-left: 24px;
     }
@@ -86,7 +86,7 @@ export class PlaygroundThemeDetector extends LitElement {
   @query('playground-code-editor')
   private _playgroundWithUserText!: PlaygroundCodeEditor;
 
-  render() {
+  override render() {
     return html`
       <h2>Theme detector</h2>
 
@@ -176,7 +176,7 @@ export class PlaygroundThemeDetector extends LitElement {
     `;
   }
 
-  async firstUpdated() {
+  override async firstUpdated() {
     // CodeMirror only renders visible lines plus some margin. Force it to
     // render everything so we can query it.
     await this._playgroundWithUserText.updateComplete;

--- a/src/internal/build.ts
+++ b/src/internal/build.ts
@@ -13,7 +13,7 @@ import {
   DiagnosticBuildOutput,
   HttpError,
 } from '../shared/worker-api.js';
-import {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver-protocol';
 
 const unreachable = (n: never) => n;
 

--- a/src/internal/build.ts
+++ b/src/internal/build.ts
@@ -6,14 +6,14 @@
 
 import {Deferred} from '../shared/deferred.js';
 
-import type {
+import {
   SampleFile,
   BuildOutput,
   FileBuildOutput,
   DiagnosticBuildOutput,
   HttpError,
 } from '../shared/worker-api.js';
-import type {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver';
 
 const unreachable = (n: never) => n;
 

--- a/src/internal/codemirror.ts
+++ b/src/internal/codemirror.ts
@@ -9,10 +9,10 @@ import '../_codemirror/codemirror-bundle.js';
 
 // Note it's critical we use `import type` here, or else we'll also import the
 // wrong runtime modules.
-import type CodeMirrorCore from 'codemirror';
-import type CoreMirrorFolding from 'codemirror/addon/fold/foldcode.js';
-import type CodeMirrorHinting from 'codemirror/addon/hint/show-hint.js';
-import type CodeMirrorComment from 'codemirror/addon/comment/comment.js';
+import CodeMirrorCore from 'codemirror';
+import CoreMirrorFolding from 'codemirror/addon/fold/foldcode.js';
+import CodeMirrorHinting from 'codemirror/addon/hint/show-hint.js';
+import CodeMirrorComment from 'codemirror/addon/comment/comment.js';
 
 /**
  * CodeMirror function.

--- a/src/internal/tab-bar.ts
+++ b/src/internal/tab-bar.ts
@@ -18,7 +18,7 @@ import {PlaygroundInternalTab} from './tab.js';
  */
 @customElement('playground-internal-tab-bar')
 export class PlaygroundInternalTabBar extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: flex;
       overflow-x: auto;
@@ -88,7 +88,7 @@ export class PlaygroundInternalTabBar extends LitElement {
   private _tabs: PlaygroundInternalTab[] = [];
   private _active: PlaygroundInternalTab | undefined = undefined;
 
-  render() {
+  override render() {
     return html`
       <div role="tablist" aria-label=${ifDefined(this.label)}>
         <slot

--- a/src/internal/tab-bar.ts
+++ b/src/internal/tab-bar.ts
@@ -8,7 +8,7 @@ import {html, css, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
-import type {PlaygroundInternalTab} from './tab.js';
+import {PlaygroundInternalTab} from './tab.js';
 
 /**
  * A horizontal bar of tabs.

--- a/src/internal/tab.ts
+++ b/src/internal/tab.ts
@@ -18,7 +18,7 @@ import {customElement, property, query} from 'lit/decorators.js';
  */
 @customElement('playground-internal-tab')
 export class PlaygroundInternalTab extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: flex;
     }
@@ -89,7 +89,7 @@ export class PlaygroundInternalTab extends LitElement {
    */
   index = 0;
 
-  render() {
+  override render() {
     return html`<button
       role="tab"
       part="button"
@@ -100,7 +100,7 @@ export class PlaygroundInternalTab extends LitElement {
     </button>`;
   }
 
-  updated(changes: PropertyValues) {
+  override updated(changes: PropertyValues) {
     if (changes.has('active') && this.active) {
       this.dispatchEvent(
         new CustomEvent<{tab?: PlaygroundInternalTab}>('tabchange', {
@@ -111,7 +111,7 @@ export class PlaygroundInternalTab extends LitElement {
     }
   }
 
-  focus() {
+  override focus() {
     this._button.focus();
   }
 }

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -19,7 +19,7 @@ import {ifDefined} from 'lit/directives/if-defined.js';
 import {CodeMirror} from './internal/codemirror.js';
 import playgroundStyles from './playground-styles.js';
 import './internal/overlay.js';
-import {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver-protocol';
 import {
   Doc,
   Editor,

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -321,7 +321,9 @@ export class PlaygroundCodeEditor extends LitElement {
               // Swapping to a document instance doesn't trigger a change event
               // which is required for document folding. Manually fold once on
               // document instantiation.
+              /* eslint-disable @typescript-eslint/no-floating-promises */
               this._applyHideAndFoldRegions();
+              /* eslint-enable @typescript-eslint/no-floating-promises */
             }
             this._valueChangingFromOutside = false;
             break;
@@ -354,7 +356,9 @@ export class PlaygroundCodeEditor extends LitElement {
             cm.setOption('readOnly', this.readonly);
             break;
           case 'pragmas':
+            /* eslint-disable @typescript-eslint/no-floating-promises */
             this._applyHideAndFoldRegions();
+            /* eslint-enable @typescript-eslint/no-floating-promises */
             break;
           case 'diagnostics':
             this._showDiagnostics();
@@ -497,7 +501,9 @@ export class PlaygroundCodeEditor extends LitElement {
       // file it is displaying.
       if (this._valueChangingFromOutside) {
         // Users can't change hide/fold regions.
+        /* eslint-disable @typescript-eslint/no-floating-promises */
         this._applyHideAndFoldRegions();
+        /* eslint-enable @typescript-eslint/no-floating-promises */
         this._showDiagnostics();
       } else {
         this.dispatchEvent(new Event('change'));
@@ -731,6 +737,7 @@ export class PlaygroundCodeEditor extends LitElement {
     // The detail promise is passed into this function only for the item
     // currently highlighted from the completions list.
     if (detail !== undefined) {
+      /* eslint-disable @typescript-eslint/no-floating-promises */
       detail.then((detailResult: EditorCompletionDetails) => {
         this._renderCompletionItemWithDetails(
           objectName,
@@ -745,6 +752,7 @@ export class PlaygroundCodeEditor extends LitElement {
           this._renderHint(element, _data, hint);
         this._currentCompletionSelectionLabel = hint.text;
       });
+      /* eslint-enable @typescript-eslint/no-floating-promises */
     }
   }
 

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -64,7 +64,7 @@ const unreachable = (n: never) => n;
  */
 @customElement('playground-code-editor')
 export class PlaygroundCodeEditor extends LitElement {
-  static styles = [
+  static override styles = [
     css`
       :host {
         display: block;
@@ -289,7 +289,7 @@ export class PlaygroundCodeEditor extends LitElement {
   private _diagnosticMarkers: Array<CodeMirror.TextMarker> = [];
   private _diagnosticsMouseoverListenerActive = false;
 
-  update(changedProperties: PropertyValues) {
+  override update(changedProperties: PropertyValues) {
     const cm = this._codemirror;
     if (cm === undefined) {
       this._createView();
@@ -381,7 +381,7 @@ export class PlaygroundCodeEditor extends LitElement {
     super.update(changedProperties);
   }
 
-  render() {
+  override render() {
     if (this.readonly) {
       return this._cmDom;
     }
@@ -416,7 +416,7 @@ export class PlaygroundCodeEditor extends LitElement {
     `;
   }
 
-  connectedCallback() {
+  override connectedCallback() {
     // CodeMirror uses JavaScript to control whether scrollbars are visible. It
     // does so automatically on interaction, but won't notice container size
     // changes. If the browser doesn't have ResizeObserver, scrollbars will
@@ -437,7 +437,7 @@ export class PlaygroundCodeEditor extends LitElement {
     super.connectedCallback();
   }
 
-  disconnectedCallback() {
+  override disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
     super.disconnectedCallback();
@@ -629,7 +629,7 @@ export class PlaygroundCodeEditor extends LitElement {
     return this.type === 'ts';
   }
 
-  focus() {
+  override focus() {
     this._codemirrorEditable?.focus();
   }
 

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -19,8 +19,8 @@ import {ifDefined} from 'lit/directives/if-defined.js';
 import {CodeMirror} from './internal/codemirror.js';
 import playgroundStyles from './playground-styles.js';
 import './internal/overlay.js';
-import type {Diagnostic} from 'vscode-languageserver';
-import type {
+import {Diagnostic} from 'vscode-languageserver';
+import {
   Doc,
   Editor,
   EditorChange,

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -11,9 +11,9 @@ import {live} from 'lit/directives/live.js';
 import './playground-code-editor.js';
 import {PlaygroundConnectedElement} from './playground-connected-element.js';
 
-import type {PlaygroundProject} from './playground-project.js';
-import type {PlaygroundCodeEditor} from './playground-code-editor.js';
-import type {CodeEditorChangeData} from './shared/worker-api.js';
+import {PlaygroundProject} from './playground-project.js';
+import {PlaygroundCodeEditor} from './playground-code-editor.js';
+import {CodeEditorChangeData} from './shared/worker-api.js';
 
 /**
  * A text editor associated with a <playground-project>.

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -20,7 +20,7 @@ import {CodeEditorChangeData} from './shared/worker-api.js';
  */
 @customElement('playground-file-editor')
 export class PlaygroundFileEditor extends PlaygroundConnectedElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: block;
       /* Prevents scrollbars from changing container size and shifting layout
@@ -102,7 +102,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
       : undefined;
   }
 
-  async update(changedProperties: PropertyValues) {
+  override async update(changedProperties: PropertyValues) {
     if (changedProperties.has('_project')) {
       const oldProject = changedProperties.get('_project') as PlaygroundProject;
       if (oldProject) {
@@ -132,7 +132,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
     super.update(changedProperties);
   }
 
-  render() {
+  override render() {
     return html`
       ${this._files
         ? html`

--- a/src/playground-file-system-controls.ts
+++ b/src/playground-file-system-controls.ts
@@ -29,7 +29,7 @@ import {PlaygroundConnectedElement} from './playground-connected-element.js';
  */
 @customElement('playground-file-system-controls')
 export class PlaygroundFileSystemControls extends PlaygroundConnectedElement {
-  static styles = css`
+  static override styles = css`
     mwc-menu-surface {
       --mdc-theme-primary: var(
         --playground-floating-controls-color,
@@ -100,14 +100,14 @@ export class PlaygroundFileSystemControls extends PlaygroundConnectedElement {
 
   private _postStateChangeRenderDone = false;
 
-  update(changedProperties: PropertyValues) {
+  override update(changedProperties: PropertyValues) {
     if (changedProperties.has('state')) {
       this._postStateChangeRenderDone = false;
     }
     super.update(changedProperties);
   }
 
-  render() {
+  override render() {
     return html`<mwc-menu-surface
       fixed
       quick
@@ -120,7 +120,7 @@ export class PlaygroundFileSystemControls extends PlaygroundConnectedElement {
     >`;
   }
 
-  async updated() {
+  override async updated() {
     if (this._postStateChangeRenderDone) {
       return;
     }

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -59,7 +59,7 @@ import {npmVersion, serviceWorkerHash} from './shared/version.js';
  */
 @customElement('playground-ide')
 export class PlaygroundIde extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: flex;
       height: 350px;
@@ -291,7 +291,7 @@ export class PlaygroundIde extends LitElement {
   private _configSetBeforeRender?: ProjectManifest;
   private _projectSrcSetBeforeRender?: string;
 
-  render() {
+  override render() {
     const projectId = 'project';
     const editorId = 'editor';
     return html`
@@ -347,7 +347,7 @@ export class PlaygroundIde extends LitElement {
     `;
   }
 
-  firstUpdated() {
+  override firstUpdated() {
     if (this._configSetBeforeRender) {
       this._project!.config = this._configSetBeforeRender;
       this._configSetBeforeRender = undefined;
@@ -358,7 +358,7 @@ export class PlaygroundIde extends LitElement {
     }
   }
 
-  async update(changedProperties: PropertyValues<this>) {
+  override async update(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('resizable') && this.resizable === false) {
       // Note we set this property on the RHS element instead of the host so
       // that when "resizable" is toggled, we don't reset a host value that the

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -21,7 +21,7 @@ import './internal/overlay.js';
  */
 @customElement('playground-preview')
 export class PlaygroundPreview extends PlaygroundConnectedElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: flex;
       flex-direction: column;
@@ -165,7 +165,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     }
   }
 
-  update(changedProperties: PropertyValues) {
+  override update(changedProperties: PropertyValues) {
     if (changedProperties.has('_project')) {
       const oldProject = changedProperties.get('_project') as PlaygroundProject;
       if (oldProject) {
@@ -191,7 +191,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     return url.toString();
   }
 
-  render() {
+  override render() {
     return html`
       <div id="toolbar" part="preview-toolbar">
         <span id="location" part="preview-location"> ${this.location}</span>
@@ -244,7 +244,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     `;
   }
 
-  updated() {
+  override updated() {
     // TODO(aomarks) If we instead use an `ifDefined(this._indexUrl)` binding in
     // the template, then the preview loads twice. I must be doing something
     // dumb, but this hacky way of synchronizing the src works correctly for
@@ -278,7 +278,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     this._showLoadingBar = true;
   };
 
-  async firstUpdated() {
+  override async firstUpdated() {
     // Loading should be initially indicated only when we're not pre-rendering,
     // because in that case there should be no visible change once the actual
     // iframe loads, and the indicator is distracting.

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -37,7 +37,7 @@ import {npmVersion, serviceWorkerHash} from './shared/version.js';
 import {Deferred} from './shared/deferred.js';
 import {PlaygroundBuild} from './internal/build.js';
 
-import {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver-protocol';
 
 // Each <playground-project> has a unique session ID used to scope requests from
 // the preview iframes.

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -367,7 +367,7 @@ export class PlaygroundProject extends LitElement {
         break;
     }
     this._pristineFiles =
-      this._files && JSON.parse(JSON.stringify(this._files));
+      this._files && (JSON.parse(JSON.stringify(this._files)) as SampleFile[]);
     this._modified = false;
     this.dispatchEvent(new FilesChangedEvent(true));
     /* eslint-disable @typescript-eslint/no-floating-promises */

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -308,7 +308,9 @@ export class PlaygroundProject extends LitElement {
 
   override async update(changedProperties: PropertyValues) {
     if (changedProperties.has('_source')) {
+      /* eslint-disable @typescript-eslint/no-floating-promises */
       this._loadProjectFromSource();
+      /* eslint-enable @typescript-eslint/no-floating-promises */
     }
     if (
       changedProperties.has('sandboxScope') ||
@@ -368,7 +370,9 @@ export class PlaygroundProject extends LitElement {
       this._files && JSON.parse(JSON.stringify(this._files));
     this._modified = false;
     this.dispatchEvent(new FilesChangedEvent(true));
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     this.save();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 
   override render() {
@@ -493,12 +497,14 @@ export class PlaygroundProject extends LitElement {
         port.removeEventListener('message', onMessage);
         if (e.data.version === serviceWorkerHash) {
           this._serviceWorkerAPI = wrap<ServiceWorkerAPI>(port);
+          /* eslint-disable @typescript-eslint/no-floating-promises */
           this._serviceWorkerAPI.setFileAPI(
             proxy({
               getFile: (name: string) => this._getFile(name),
             }),
             this._sessionId
           );
+          /* eslint-enable @typescript-eslint/no-floating-promises */
         } else {
           // Version mismatch. Request the service worker be updated
           // immediately. We'll get back here again after it updates via a
@@ -563,11 +569,13 @@ export class PlaygroundProject extends LitElement {
     if (build.state() !== 'active') {
       return;
     }
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     workerApi.compileProject(
       this._files ?? [],
       {importMap: this._importMap},
       proxy((result) => build.onOutput(result))
     );
+    /* eslint-enable @typescript-eslint/no-floating-promises */
     await build.stateChange;
     if (build.state() !== 'done') {
       return;
@@ -679,7 +687,9 @@ export class PlaygroundProject extends LitElement {
     // want to be doing any searches.
     file.content = newContent;
     this._modified = undefined;
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     this.saveDebounced();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 
   addFile(name: string) {
@@ -701,7 +711,9 @@ export class PlaygroundProject extends LitElement {
     this._modified = undefined;
     this.requestUpdate();
     this.dispatchEvent(new FilesChangedEvent());
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     this.save();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 
   deleteFile(filename: string) {
@@ -715,7 +727,9 @@ export class PlaygroundProject extends LitElement {
     this._files = [...this._files.slice(0, idx), ...this._files.slice(idx + 1)];
     this._modified = undefined;
     this.dispatchEvent(new FilesChangedEvent());
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     this.save();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 
   renameFile(oldName: string, newName: string) {
@@ -735,7 +749,9 @@ export class PlaygroundProject extends LitElement {
     this._files = [...this._files];
     this._modified = undefined;
     this.dispatchEvent(new FilesChangedEvent());
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     this.save();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 }
 

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -300,13 +300,13 @@ export class PlaygroundProject extends LitElement {
     ).href;
   }
 
-  static styles = css`
+  static override styles = css`
     iframe {
       display: none;
     }
   `;
 
-  async update(changedProperties: PropertyValues) {
+  override async update(changedProperties: PropertyValues) {
     if (changedProperties.has('_source')) {
       this._loadProjectFromSource();
     }
@@ -371,7 +371,7 @@ export class PlaygroundProject extends LitElement {
     this.save();
   }
 
-  render() {
+  override render() {
     return html`
       <slot @slotchange=${this._slotChange}></slot>
       <iframe
@@ -440,7 +440,7 @@ export class PlaygroundProject extends LitElement {
     }
   }
 
-  async firstUpdated() {
+  override async firstUpdated() {
     const typescriptWorkerScriptUrl = forceSkypackRawMode(
       new URL('./playground-typescript-worker.js', import.meta.url)
     );

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -37,7 +37,7 @@ import {npmVersion, serviceWorkerHash} from './shared/version.js';
 import {Deferred} from './shared/deferred.js';
 import {PlaygroundBuild} from './internal/build.js';
 
-import type {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver';
 
 // Each <playground-project> has a unique session ID used to scope requests from
 // the preview iframes.

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -483,7 +483,6 @@ export class PlaygroundProject extends LitElement {
     this._postMessageToServiceWorkerProxyIframe(
       {
         type: CONFIGURE_PROXY,
-        url: 'playground-service-worker.js',
         scope: this.sandboxScope,
         port: port2,
       },

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -13,6 +13,7 @@ import {
   UPDATE_SERVICE_WORKER,
 } from './shared/worker-api.js';
 
+/* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   try {
     // Note we detect same-origin here by actually trying to access the parent
@@ -118,12 +119,16 @@ import {
     sw.postMessage(swMessage, [port2]);
   };
 
+  /* eslint-disable @typescript-eslint/no-floating-promises */
   connectToNewest();
+  /* eslint-enable @typescript-eslint/no-floating-promises */
 
   registration.addEventListener('updatefound', () => {
     // We can get a new service worker at any time, so we need to listen for
     // updates and connect to new workers on demand.
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     connectToNewest();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   });
 
   // A message from the service worker.
@@ -143,7 +148,9 @@ import {
         // Force required because we usually avoid connecting to a service
         // worker we've already connected to, but in this case that's exactly
         // what we must do.
+        /* eslint-disable @typescript-eslint/no-floating-promises */
         connectToNewest(true);
+        /* eslint-enable @typescript-eslint/no-floating-promises */
       }
     }
   );
@@ -175,3 +182,4 @@ import {
     }
   );
 })();
+/* eslint-enable @typescript-eslint/no-floating-promises */

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -30,12 +30,7 @@ import {
   // Wait for our parent to send us:
   // 1. The URL and scope of the Service Worker to register.
   // 2. A MessagePort, on which we'll forward up new Service Worker ports.
-  const {
-    url,
-    scope,
-    port: parentPort,
-  } = await new Promise<{
-    url: string;
+  const {scope, port: parentPort} = await new Promise<{
     scope: string;
     port: MessagePort;
   }>((resolve) => {
@@ -49,7 +44,7 @@ import {
   });
 
   const registration = await navigator.serviceWorker.register(
-    new URL(url, import.meta.url).href,
+    new URL('playground-service-worker.js', import.meta.url).href,
     {scope}
   );
 

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -26,7 +26,7 @@ import {PlaygroundInternalTab} from './internal/tab.js';
  */
 @customElement('playground-tab-bar')
 export class PlaygroundTabBar extends PlaygroundConnectedElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: flex;
       font-size: var(--playground-tab-bar-font-size, 14px);
@@ -136,7 +136,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     return (this._project?.files ?? []).filter(({hidden}) => !hidden);
   }
 
-  update(changedProperties: PropertyValues) {
+  override update(changedProperties: PropertyValues) {
     if (changedProperties.has('_project')) {
       const oldProject = changedProperties.get('_project') as PlaygroundProject;
       if (oldProject) {
@@ -160,7 +160,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     super.update(changedProperties);
   }
 
-  render() {
+  override render() {
     return html`
       <playground-internal-tab-bar
         @tabchange=${this._onTabchange}

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -15,13 +15,10 @@ import './playground-file-system-controls.js';
 
 import {PlaygroundConnectedElement} from './playground-connected-element.js';
 
-import type {PlaygroundFileEditor} from './playground-file-editor.js';
-import type {PlaygroundFileSystemControls} from './playground-file-system-controls.js';
-import type {
-  FilesChangedEvent,
-  PlaygroundProject,
-} from './playground-project.js';
-import type {PlaygroundInternalTab} from './internal/tab.js';
+import {PlaygroundFileEditor} from './playground-file-editor.js';
+import {PlaygroundFileSystemControls} from './playground-file-system-controls.js';
+import {FilesChangedEvent, PlaygroundProject} from './playground-project.js';
+import {PlaygroundInternalTab} from './internal/tab.js';
 
 /**
  * A horizontal bar of tabs for switching between playground files, with

--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -151,7 +151,9 @@ const parseScopedUrl = (url: string) => {
 const onInstall = () => {
   // Force this service worker to become the active service worker, in case
   // it's an updated worker and waiting.
+  /* eslint-disable @typescript-eslint/no-floating-promises */
   self.skipWaiting();
+  /* eslint-enable @typescript-eslint/no-floating-promises */
 };
 
 const onActivate = (event: ExtendableEvent) => {

--- a/src/shared/completion-utils.ts
+++ b/src/shared/completion-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import Fuse from 'fuse.js';
-import type {CompletionInfo} from 'typescript';
+import {CompletionInfo} from 'typescript';
 import {
   EditorCompletion,
   EditorCompletionMatch,

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -46,7 +46,6 @@ export const UPDATE_SERVICE_WORKER = 6;
 export type PlaygroundMessage =
   | {
       type: typeof CONFIGURE_PROXY;
-      url: string;
       scope: string;
       port: MessagePort;
     }

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -5,7 +5,7 @@
  */
 
 import {CompletionEntry, CompletionInfo, WithMetadata} from 'typescript';
-import type {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver';
 
 /**
  * Sent from the project to the proxy, with configuration and a port for further

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -5,7 +5,7 @@
  */
 
 import {CompletionEntry, CompletionInfo, WithMetadata} from 'typescript';
-import {Diagnostic} from 'vscode-languageserver';
+import {Diagnostic} from 'vscode-languageserver-protocol';
 
 /**
  * Sent from the project to the proxy, with configuration and a port for further

--- a/src/test/bare-module-worker_test.ts
+++ b/src/test/bare-module-worker_test.ts
@@ -6,12 +6,12 @@
 
 import {checkTransform} from './worker-test-util.js';
 
-import type {
+import {
   BuildOutput,
   ModuleImportMap,
   SampleFile,
 } from '../shared/worker-api.js';
-import type {CdnData} from './fake-cdn-plugin.js';
+import {CdnData} from './fake-cdn-plugin.js';
 
 const browser = (() => {
   const ua = navigator.userAgent;

--- a/src/test/fake-cdn-plugin.ts
+++ b/src/test/fake-cdn-plugin.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import type {TestRunnerPlugin} from '@web/test-runner-core/dist/server/TestRunnerPlugin.js';
+import {TestRunnerPlugin} from '@web/test-runner-core/dist/server/TestRunnerPlugin.js';
 import semver from 'semver';
 
 /**

--- a/src/test/node-module-resolver_test.ts
+++ b/src/test/node-module-resolver_test.ts
@@ -7,7 +7,7 @@
 import {assert} from '@esm-bundle/chai';
 import {NodeModuleResolver} from '../typescript-worker/node-module-resolver.js';
 
-import type {PackageJson} from '../typescript-worker/util.js';
+import {PackageJson} from '../typescript-worker/util.js';
 
 suite('NodeModuleResolver', () => {
   const check = ({

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -10,11 +10,11 @@ import {PlaygroundIde} from '../playground-ide.js';
 import '../playground-ide.js';
 import {sendKeys, executeServerCommand} from '@web/test-runner-commands';
 
-import type {ReactiveElement} from '@lit/reactive-element';
-import type {PlaygroundCodeEditor} from '../playground-code-editor.js';
-import type {PlaygroundProject} from '../playground-project.js';
-import type {PlaygroundFileEditor} from '../playground-file-editor.js';
-import type {PlaygroundPreview} from '../playground-preview.js';
+import {ReactiveElement} from '@lit/reactive-element';
+import {PlaygroundCodeEditor} from '../playground-code-editor.js';
+import {PlaygroundProject} from '../playground-project.js';
+import {PlaygroundFileEditor} from '../playground-file-editor.js';
+import {PlaygroundPreview} from '../playground-preview.js';
 
 // There is browser variability with zero width spaces. This helper keeps tests
 // consistent.
@@ -243,7 +243,7 @@ suite('playground-ide', () => {
                 return document.createTextNode(children);
               }
             }
-            
+
             class ReactRoot {
               root;
               constructor(root) {
@@ -253,13 +253,13 @@ suite('playground-ide', () => {
                 this.root.appendChild(children);
               }
             }
-            
+
             class ReactDOM {
               static createRoot(root) {
                 return new ReactRoot(root);
               }
             }
-            
+
             export {React, ReactDOM};
           `,
         },
@@ -309,7 +309,7 @@ suite('playground-ide', () => {
                 return document.createTextNode(children);
               }
             }
-            
+
             class ReactRoot {
               root: HTMLElement;
               constructor(root: HTMLElement) {
@@ -319,13 +319,13 @@ suite('playground-ide', () => {
                 this.root.appendChild(children);
               }
             }
-            
+
             class ReactDOM {
               static createRoot(root: HTMLElement): ReactRoot {
                 return new ReactRoot(root);
               }
             }
-            
+
             export {React, ReactDOM};
           `,
         },

--- a/src/test/playwright/service-worker.spec.ts
+++ b/src/test/playwright/service-worker.spec.ts
@@ -10,8 +10,8 @@ import {readFile} from 'fs/promises';
 // eslint-disable-next-line import/extensions
 import {Deferred} from '../../shared/deferred';
 
-import type {Page} from 'playwright';
-import type {DevServer, Plugin} from '@web/dev-server-core';
+import {Page} from 'playwright';
+import {DevServer, Plugin} from '@web/dev-server-core';
 
 const indexHtml = `
 <!DOCTYPE html>

--- a/src/test/types-fetcher_test.ts
+++ b/src/test/types-fetcher_test.ts
@@ -10,10 +10,10 @@ import {configureFakeCdn} from './worker-test-util.js';
 import {assert} from '@esm-bundle/chai';
 import {CachingCdn} from '../typescript-worker/caching-cdn.js';
 
-import type {ModuleImportMap} from '../shared/worker-api.js';
-import type {CdnData} from './fake-cdn-plugin.js';
-import type {PackageJson} from '../typescript-worker/util.js';
-import type {
+import {ModuleImportMap} from '../shared/worker-api.js';
+import {CdnData} from './fake-cdn-plugin.js';
+import {PackageJson} from '../typescript-worker/util.js';
+import {
   DependencyGraph,
   NodeModulesDirectory,
   PackageDependencies,

--- a/src/test/typescript-worker_test.ts
+++ b/src/test/typescript-worker_test.ts
@@ -6,8 +6,8 @@
 
 import {checkTransform} from './worker-test-util.js';
 
-import type {BuildOutput, SampleFile} from '../shared/worker-api.js';
-import type {CdnData} from './fake-cdn-plugin.js';
+import {BuildOutput, SampleFile} from '../shared/worker-api.js';
+import {CdnData} from './fake-cdn-plugin.js';
 
 suite('typescript builder', () => {
   test('empty project', async () => {
@@ -279,7 +279,7 @@ suite('typescript builder', () => {
               },
               'index.d.ts': {
                 content: `
-                  import type {t} from './type.js';
+                  import {t} from './type.js';
                   export declare const foo: (s: t) => t;
                 `,
               },

--- a/src/test/typescript-worker_test.ts
+++ b/src/test/typescript-worker_test.ts
@@ -279,7 +279,7 @@ suite('typescript builder', () => {
               },
               'index.d.ts': {
                 content: `
-                  import {t} from './type.js';
+                  import type {t} from './type.js';
                   export declare const foo: (s: t) => t;
                 `,
               },

--- a/src/test/worker-test-util.ts
+++ b/src/test/worker-test-util.ts
@@ -8,12 +8,12 @@ import {assert} from '@esm-bundle/chai';
 import {build} from '../typescript-worker/build.js';
 import {executeServerCommand} from '@web/test-runner-commands';
 
-import type {
+import {
   BuildOutput,
   ModuleImportMap,
   SampleFile,
 } from '../shared/worker-api.js';
-import type {CdnData} from './fake-cdn-plugin.js';
+import {CdnData} from './fake-cdn-plugin.js';
 
 export const configureFakeCdn = async (
   data: CdnData

--- a/src/typescript-worker/bare-module-transformer.ts
+++ b/src/typescript-worker/bare-module-transformer.ts
@@ -17,15 +17,15 @@ import {
 import {Deferred} from '../shared/deferred.js';
 import {NodeModuleResolver} from './node-module-resolver.js';
 
-import type {
+import {
   BuildOutput,
   DiagnosticBuildOutput,
   FileBuildOutput,
   SampleFile,
 } from '../shared/worker-api.js';
-import type {ImportMapResolver} from './import-map-resolver.js';
-import type {CachingCdn} from './caching-cdn.js';
-import type {NpmFileLocation, PackageJson} from './util.js';
+import {ImportMapResolver} from './import-map-resolver.js';
+import {CachingCdn} from './caching-cdn.js';
+import {NpmFileLocation, PackageJson} from './util.js';
 
 /**
  * Transforms bare module specifiers in .js files to canonical local paths, and

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -6,11 +6,7 @@
 
 import {BareModuleTransformer} from './bare-module-transformer.js';
 
-import type {
-  SampleFile,
-  BuildOutput,
-  WorkerConfig,
-} from '../shared/worker-api.js';
+import {SampleFile, BuildOutput, WorkerConfig} from '../shared/worker-api.js';
 import {getWorkerContext} from './worker-context.js';
 import {processTypeScriptFiles} from './typescript-builder.js';
 

--- a/src/typescript-worker/caching-cdn.ts
+++ b/src/typescript-worker/caching-cdn.ts
@@ -13,7 +13,7 @@ import {
 } from './util.js';
 import {Deferred} from '../shared/deferred.js';
 
-import type {NpmFileLocation, PackageJson} from './util.js';
+import {NpmFileLocation, PackageJson} from './util.js';
 
 export interface CdnFile {
   content: string;

--- a/src/typescript-worker/completions.ts
+++ b/src/typescript-worker/completions.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import type {
+import {
   CompletionInfo,
   GetCompletionsAtPositionOptions,
   SymbolDisplayPart,

--- a/src/typescript-worker/diagnostic.ts
+++ b/src/typescript-worker/diagnostic.ts
@@ -5,7 +5,7 @@
  */
 
 import ts from '../internal/typescript.js';
-import * as lsp from 'vscode-languageserver';
+import * as lsp from 'vscode-languageserver-protocol';
 
 /**
  * Convert a diagnostic from TypeScript format to Language Server Protocol
@@ -35,7 +35,7 @@ export function makeLspDiagnostic(tsDiagnostic: ts.Diagnostic): lsp.Diagnostic {
 }
 
 /**
- * We don't want a runtime import of 'vscode-languageserver' just for the
+ * We don't want a runtime import of 'vscode-languageserver-protocol' just for the
  * DiagnosticSeverity constants. We can duplicate the values instead, and assert
  * we got them right with a type constraint.
  */

--- a/src/typescript-worker/diagnostic.ts
+++ b/src/typescript-worker/diagnostic.ts
@@ -5,7 +5,7 @@
  */
 
 import ts from '../internal/typescript.js';
-import type * as lsp from 'vscode-languageserver';
+import * as lsp from 'vscode-languageserver';
 
 /**
  * Convert a diagnostic from TypeScript format to Language Server Protocol

--- a/src/typescript-worker/node-module-resolver.ts
+++ b/src/typescript-worker/node-module-resolver.ts
@@ -5,11 +5,7 @@
  */
 
 import {packageExportsResolve} from './node/resolve.js';
-import type {
-  NpmFileLocation,
-  PackageJson,
-  PackageJsonWithExports,
-} from './util.js';
+import {NpmFileLocation, PackageJson, PackageJsonWithExports} from './util.js';
 
 /**
  * Resolves a path according to the Node package exports algorithm.

--- a/src/typescript-worker/node/errors.ts
+++ b/src/typescript-worker/node/errors.ts
@@ -9,7 +9,7 @@
 // and adapted for use in playground-elements.
 
 import {fileURLToPath} from './url.js';
-import type {PackageExportsTarget} from '../util.js';
+import {PackageExportsTarget} from '../util.js';
 
 export class InvalidModuleSpecifierError extends Error {
   constructor(request: string, reason: string, base?: string) {

--- a/src/typescript-worker/node/resolve.ts
+++ b/src/typescript-worker/node/resolve.ts
@@ -15,7 +15,7 @@ import {
   InvalidPackageTargetError,
   PackagePathNotExportedError,
 } from './errors.js';
-import type {
+import {
   PackageExports,
   PackageExportsPathOrConditionMap,
   PackageExportsTarget,

--- a/src/typescript-worker/node/resolve.ts
+++ b/src/typescript-worker/node/resolve.ts
@@ -275,18 +275,21 @@ function resolvePackageTarget(
 }
 
 function isConditionalExportsMainSugar(
-  exports: PackageExports,
+  // Note we are avoiding locals called exactly "exports" because of
+  // incompatibilities with JS Compiler which can produce code that expects to
+  // be able to reference a global called "exports".
+  _exports: PackageExports,
   packageJSONUrl: URL,
   base: string
 ): boolean {
-  if (typeof exports === 'string' || Array.isArray(exports)) {
+  if (typeof _exports === 'string' || Array.isArray(_exports)) {
     return true;
   }
-  if (typeof exports !== 'object' || exports === null) {
+  if (typeof _exports !== 'object' || _exports === null) {
     return false;
   }
 
-  const keys = Object.getOwnPropertyNames(exports);
+  const keys = Object.getOwnPropertyNames(_exports);
   let isConditionalSugar = false;
   let i = 0;
   for (let j = 0; j < keys.length; j++) {
@@ -314,18 +317,18 @@ export function packageExportsResolve(
   base: string,
   conditions: Set<string>
 ): URL {
-  let exports = packageConfig.exports;
-  if (isConditionalExportsMainSugar(exports, packageJSONUrl, base)) {
-    exports = {'.': exports};
+  let _exports = packageConfig.exports;
+  if (isConditionalExportsMainSugar(_exports, packageJSONUrl, base)) {
+    _exports = {'.': _exports};
   }
-  exports = exports as PackageExportsPathOrConditionMap;
+  _exports = _exports as PackageExportsPathOrConditionMap;
 
   if (
-    Object.prototype.hasOwnProperty.call(exports, packageSubpath) &&
+    Object.prototype.hasOwnProperty.call(_exports, packageSubpath) &&
     !packageSubpath.includes('*') &&
     !packageSubpath.endsWith('/')
   ) {
-    const target = exports[packageSubpath];
+    const target = _exports[packageSubpath];
     const resolved = resolvePackageTarget(
       packageJSONUrl,
       target,
@@ -344,7 +347,7 @@ export function packageExportsResolve(
 
   let bestMatch = '';
   let bestMatchSubpath: string | undefined = undefined;
-  for (const key of Object.keys(exports)) {
+  for (const key of Object.keys(_exports)) {
     const patternIndex = key.indexOf('*');
     if (
       patternIndex !== -1 &&
@@ -374,7 +377,7 @@ export function packageExportsResolve(
   }
 
   if (bestMatch) {
-    const target = exports[bestMatch];
+    const target = _exports[bestMatch];
     const pattern = bestMatch.includes('*');
     const resolved = resolvePackageTarget(
       packageJSONUrl,

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -6,7 +6,7 @@
 
 import {expose} from 'comlink';
 import {build} from './build.js';
-import type {WorkerAPI} from '../shared/worker-api.js';
+import {WorkerAPI} from '../shared/worker-api.js';
 import {getCompletionItemDetails, queryCompletions} from './completions.js';
 
 const workerAPI: WorkerAPI = {

--- a/src/typescript-worker/types-fetcher.ts
+++ b/src/typescript-worker/types-fetcher.ts
@@ -16,9 +16,9 @@ import {
   trimLeadingSlash,
 } from './util.js';
 
-import type {Result} from '../shared/util.js';
-import type {CachingCdn} from './caching-cdn.js';
-import type {PackageJson, NpmFileLocation} from './util.js';
+import {Result} from '../shared/util.js';
+import {CachingCdn} from './caching-cdn.js';
+import {PackageJson, NpmFileLocation} from './util.js';
 import {
   PackageDependencies,
   DependencyGraph,

--- a/src/typescript-worker/types-fetcher.ts
+++ b/src/typescript-worker/types-fetcher.ts
@@ -99,7 +99,7 @@ export class TypesFetcher {
       fetcher._rootDependencies,
       fetcher._dependencyGraph
     );
-    const files = new Map();
+    const files = new Map<string, string>();
     await fetcher._materializeNodeModulesTree(layout, files, '');
     // Note in practice we only really need "files", but it's useful to also
     // return the dependency graph and layout for testing.

--- a/src/typescript-worker/util.ts
+++ b/src/typescript-worker/util.ts
@@ -37,6 +37,7 @@ export class MergedAsyncIterables<T> {
       );
     }
     this._numSources++;
+    /* eslint-disable @typescript-eslint/no-floating-promises */
     (async () => {
       for await (const value of iterable) {
         // Wait for this value to be emitted before continuing
@@ -48,6 +49,7 @@ export class MergedAsyncIterables<T> {
       this._numSources--;
       this._notify?.();
     })();
+    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "importHelpers": true,
     // TODO(aomarks) Remove when
     // https://github.com/material-components/material-web/issues/2715 is fixed.
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noImplicitOverride": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Various changes to make it easier to import playground elements into Google:

- Remove `import type` statements.
- Require explicit `override` keywords.
- Replace `vscode-languageserver` dep with `vscode-languageserver-protocol`.
- Detect and annotate floating promises, so that they can be auto transformed to have the required annotation internally.
- Upgrade from TypeScript 4.4.4 to 4.7.4, and use `~` semver range going forward.
- Add explicit cast for a `JSON.parse` call.
- Add explicit type parameters for a `new Map` call.
- Rename variables called `exports` to `_exports`, because JS Compiler assumes it can always unambiguously refer to a global with that name.
- Simplify part of the project -> service worker proxy protocol. We used to pass the service worker URL over the wire, but since it's static there is no point doing that (simplifies some internal security transforms).