### PR TITLE
More modifications for Google import compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Removed `vscode-languageserver` dependency.
 - TypeScript version upgraded from `4.4.4` to `4.7.4`.
+- `PlaygroundConnectedElement` `project` is now permitted to be `undefined` according to TypeScript.
 
 ## [0.16.3] - 2022-08-02
 

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -639,7 +639,8 @@ export class PlaygroundCodeEditor extends LitElement {
     this._codemirrorEditable?.focus();
   }
 
-  private _completionsAsHints(cm: Editor): Hints {
+  private _completionsAsHints(): Hints {
+    const cm = this._codemirror!;
     const cursorPosition = cm.getCursor('start');
     const token = cm.getTokenAt(cursorPosition);
     const lineNumber = cursorPosition.line;

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -135,7 +135,7 @@ export class PlaygroundCodeEditor extends LitElement {
     playgroundStyles,
   ];
 
-  protected _codemirror?: ReturnType<typeof CodeMirror>;
+  protected _codemirror?: CodeMirror.Editor;
 
   get cursorPosition(): EditorPosition {
     const cursor = this._codemirror?.getCursor('start');

--- a/src/playground-connected-element.ts
+++ b/src/playground-connected-element.ts
@@ -17,7 +17,7 @@ export class PlaygroundConnectedElement extends LitElement {
    * `<playground-project>` node itself, or its `id` in the host scope.
    */
   @property()
-  set project(elementOrId: PlaygroundProject | string) {
+  set project(elementOrId: PlaygroundProject | string | undefined) {
     if (typeof elementOrId === 'string') {
       // Defer querying the host to a rAF because if the host renders this
       // element before the one we're querying for, it might not quite exist

--- a/src/playground-file-system-controls.ts
+++ b/src/playground-file-system-controls.ts
@@ -112,9 +112,9 @@ export class PlaygroundFileSystemControls extends PlaygroundConnectedElement {
       fixed
       quick
       .open=${this.state !== 'closed'}
-      .anchor=${this.anchorElement}
+      .anchor=${this.anchorElement ?? null}
       corner="BOTTOM_START"
-      .classList=${this.state}
+      class="${this.state}"
       @closed=${this._onSurfaceClosed}
       ><div class="wrapper">${this._surfaceContents}</div></mwc-menu-surface
     >`;

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -252,7 +252,7 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     if (!tab) {
       return;
     }
-    const name = tab.dataset.filename!;
+    const name = tab.dataset['filename']!;
     const index = tab.index!;
     if (name !== this._activeFileName) {
       this._activeFileName = name;
@@ -279,8 +279,8 @@ export class PlaygroundTabBar extends PlaygroundConnectedElement {
     // Between MWC v0.25.1 and v0.25.2, when clicking on an <mwc-icon-button>,
     // the target changed from the <mwc-icon-button> to its internal <svg>.
     for (const el of event.composedPath()) {
-      if (el instanceof HTMLElement && el.dataset.filename) {
-        controls.filename = el.dataset.filename;
+      if (el instanceof HTMLElement && el.dataset['filename']) {
+        controls.filename = el.dataset['filename'];
         break;
       }
     }

--- a/src/test/playwright/service-worker.spec.ts
+++ b/src/test/playwright/service-worker.spec.ts
@@ -90,7 +90,7 @@ test.describe('service worker', () => {
           `Found ${versionMatches.length}.`
       );
     }
-    const hex = versionMatches[0].groups?.hex;
+    const hex = versionMatches[0].groups?.['hex'];
     if (!hex) {
       throw new Error('Could not find "hex" capture group in regexp match.');
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     // TODO(aomarks) Remove when
     // https://github.com/material-components/material-web/issues/2715 is fixed.
     "skipLibCheck": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
- Minor prop/attribute tweaks to make Lit analyzer happy
- Simpler type for `CodeMirror.Editor`
- Use class codemirror property instead of parameter
- Enforce `noPropertyAccessFromIndexSignature`
- Allow explicitly setting `project` to `undefined`