### PR TITLE
Add require-corp embedder policy header to service worker

### DIFF
--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -112,6 +112,7 @@ const getFile = async (_e: FetchEvent, path: string, sessionId: SessionID) => {
   // https://web.dev/origin-agent-cluster/
   // https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters
   headers.set('Origin-Agent-Cluster', '?1');
+  headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
   if (contentType) {
     headers.set('Content-Type', contentType);
   }


### PR DESCRIPTION
Upstream a recommended header that enforces CORS (as far as I can tell).
Reference to documentation: https://html.spec.whatwg.org/multipage/origin.html#coep

I tested this using the configurator page and a relatively complex demo. However I'm not certain that this is an appropriate test for a modification to the service worker.

https://user-images.githubusercontent.com/15080861/194410336-8bb12c31-fa45-469d-bdf0-7d8f6ad95901.mov
