### PR TITLE
Update codemirror types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@material/mwc-list": "^0.27.0",
         "@material/mwc-menu": "^0.27.0",
         "@material/mwc-textfield": "^0.27.0",
-        "@types/codemirror": "^5.60.0",
+        "@types/codemirror": "^5.60.7",
         "comlink": "=4.3.1",
         "fuse.js": "^6.4.6",
         "lit": "^2.0.0",
@@ -967,9 +967,9 @@
       }
     },
     "node_modules/@types/codemirror": {
-      "version": "5.60.5",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
-      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
+      "version": "5.60.7",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.7.tgz",
+      "integrity": "sha512-QXIC+RPzt/1BGSuD6iFn6UMC9TDp+9hkOANYNPVsjjrDdzKphfRkwQDKGp2YaC54Yhz0g6P5uYTCCibZZEiMAA==",
       "dependencies": {
         "@types/tern": "*"
       }

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
     "@material/mwc-list": "^0.27.0",
     "@material/mwc-menu": "^0.27.0",
     "@material/mwc-textfield": "^0.27.0",
-    "@types/codemirror": "^5.60.0",
+    "@types/codemirror": "^5.60.7",
     "comlink": "=4.3.1",
     "fuse.js": "^6.4.6",
     "lit": "^2.0.0",


### PR DESCRIPTION
Apply https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64011

Makes the codemirror types compatible with TypeScript 5.0