### PR TITLE
Update TypeScript to 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Update bundled version of TypeScript from `4.8.4` to `5.0.4`.
+- **BREAKING** Update bundled version of TypeScript from `4.8.4` to `5.0.4`. See [TypeScript 5 breaking changes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#breaking-changes-and-deprecations).
 
 ## [0.17.1] - 2023-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Update bundled version of TypeScript from `4.8.4` to `5.0.4`.
 
 ## [0.17.1] - 2023-04-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "rollup-plugin-copy": "^3.3.0",
         "rollup-plugin-lit-css": "^4.0.0",
         "semver": "^7.3.5",
-        "typescript": "~4.8.4",
+        "typescript": "~5.0.4",
         "wireit": "^0.7.3-pre.3"
       }
     },
@@ -6186,16 +6186,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/typical": {

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-lit-css": "^4.0.0",
     "semver": "^7.3.5",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "wireit": "^0.7.3-pre.3"
   },
   "dependencies": {

--- a/src/test/typescript-worker_test.ts
+++ b/src/test/typescript-worker_test.ts
@@ -28,7 +28,7 @@ suite('typescript builder', () => {
         kind: 'file',
         file: {
           name: 'index.js',
-          content: 'export const foo = 3;\r\n',
+          content: 'export const foo = 3;\n',
           contentType: 'text/javascript',
         },
       },
@@ -89,7 +89,7 @@ suite('typescript builder', () => {
           name: 'index.js',
           // TODO(aomarks) This should probably return a 400 error instead of an
           // empty but valid file.
-          content: 'export {};\r\n',
+          content: 'export {};\n',
           contentType: 'text/javascript',
         },
       },
@@ -132,7 +132,7 @@ suite('typescript builder', () => {
         kind: 'file',
         file: {
           name: 'index.js',
-          content: 'let foo = 3;\r\n' + 'foo = "foo";\r\nexport {};\r\n',
+          content: 'let foo = 3;\n' + 'foo = "foo";\nexport {};\n',
           contentType: 'text/javascript',
         },
       },
@@ -225,7 +225,7 @@ suite('typescript builder', () => {
         file: {
           name: 'index.js',
           content:
-            'import { strFn } from "./node_modules/foo@2.0.0/index.js";\r\nimport { numFn } from "./node_modules/foo@2.0.0/bar.js";\r\nstrFn(123);\r\nnumFn("str");\r\n',
+            'import { strFn } from "./node_modules/foo@2.0.0/index.js";\nimport { numFn } from "./node_modules/foo@2.0.0/bar.js";\nstrFn(123);\nnumFn("str");\n',
           contentType: 'text/javascript',
         },
       },
@@ -328,7 +328,7 @@ suite('typescript builder', () => {
         file: {
           name: 'index.js',
           content:
-            'import { foo } from "./node_modules/foo@1.0.0/index.js";\r\nfoo(123);\r\n',
+            'import { foo } from "./node_modules/foo@1.0.0/index.js";\nfoo(123);\n',
           contentType: 'text/javascript',
         },
       },
@@ -452,7 +452,7 @@ suite('typescript builder', () => {
         kind: 'file',
         file: {
           name: 'index.js',
-          content: `export const str = "foo";\r\n`,
+          content: `export const str = "foo";\n`,
           contentType: 'text/javascript',
         },
       },
@@ -551,7 +551,7 @@ suite('typescript builder', () => {
         file: {
           name: 'index.js',
           content:
-            'import { num } from "./node_modules/foo@1.0.0/index.js";\r\nimport { str } from "./node_modules/str-or-num@1.0.0/index.js";\r\nconst a = str;\r\nconst b = num;\r\n',
+            'import { num } from "./node_modules/foo@1.0.0/index.js";\nimport { str } from "./node_modules/str-or-num@1.0.0/index.js";\nconst a = str;\nconst b = num;\n',
           contentType: 'text/javascript',
         },
       },
@@ -616,7 +616,7 @@ suite('typescript builder', () => {
         file: {
           name: 'index.js',
           content:
-            'import React from "./node_modules/react@18.1.0/index.js";\r\nexport const foo = (greeting) => React.createElement("div", null, greeting);\r\n',
+            'import React from "./node_modules/react@18.1.0/index.js";\nexport const foo = (greeting) => React.createElement("div", null, greeting);\n',
           contentType: 'text/javascript',
         },
       },
@@ -681,7 +681,7 @@ suite('typescript builder', () => {
         file: {
           name: 'index.js',
           content:
-            'import * as React from "./node_modules/react@18.1.0/index.js";\r\nexport const foo = (greeting) => React.createElement("div", null, greeting);\r\n',
+            'import * as React from "./node_modules/react@18.1.0/index.js";\nexport const foo = (greeting) => React.createElement("div", null, greeting);\n',
           contentType: 'text/javascript',
         },
       },


### PR DESCRIPTION
### Context

Keep TypeScript up to date & fix internal compiler error in https://github.com/lit/lit.dev/issues/1128.

### Testing

 - Updated unit tests with the subtle newline change: `\r\n` -> `\n`.

Manually tested using `npm run serve`