### PR TITLE
Gracefully handle a TypeScript compiler crash once

### DIFF
--- a/src/internal/build.ts
+++ b/src/internal/build.ts
@@ -17,7 +17,7 @@ import {Diagnostic} from 'vscode-languageserver-protocol';
 
 const unreachable = (n: never) => n;
 
-type State = 'active' | 'done' | 'cancelled';
+type State = 'active' | 'done' | 'cancelled' | 'crashed';
 
 const errorNotFound: HttpError = {
   status: /* Not Found */ 404,
@@ -106,6 +106,10 @@ export class PlaygroundBuild {
       this._onDiagnostic(output);
     } else if (output.kind === 'done') {
       this._onDone();
+    } else if (output.kind === 'crash') {
+      this.cancel();
+      console.warn('TypeScript worker crashed with message: ', output.msg);
+      this._changeState('crashed');
     } else {
       throw new Error(
         `Unexpected BuildOutput kind: ${

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -140,6 +140,15 @@ export interface WorkerAPI {
     config: WorkerConfig,
     completionWord: string
   ): Promise<EditorCompletionDetails>;
+  /**
+   * `getFreshWorkerContext` can be used to guarantee a fresh TypeScript
+   * context.
+   *
+   * By default the worker context is persistent and incremental for a given
+   * config. This function can be used to gracefully handle rare cases where the
+   * TypeScript compiler is crashing due to bad incremental state.
+   */
+  getFreshWorkerContext(config: WorkerConfig): void;
 }
 
 export interface HttpError {
@@ -213,7 +222,11 @@ export interface CompletionInfoWithDetails
   entries: CompletionEntryWithDetails[];
 }
 
-export type BuildOutput = FileBuildOutput | DiagnosticBuildOutput | DoneOutput;
+export type BuildOutput =
+  | FileBuildOutput
+  | DiagnosticBuildOutput
+  | DoneOutput
+  | TypeScriptCompilerCrash;
 
 export type FileBuildOutput = {
   kind: 'file';
@@ -228,4 +241,9 @@ export type DiagnosticBuildOutput = {
 
 export type DoneOutput = {
   kind: 'done';
+};
+
+export type TypeScriptCompilerCrash = {
+  kind: 'crash';
+  msg: string;
 };

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -6,12 +6,16 @@
 
 import {expose} from 'comlink';
 import {build} from './build.js';
-import {WorkerAPI} from '../shared/worker-api.js';
+import {WorkerAPI, WorkerConfig} from '../shared/worker-api.js';
 import {getCompletionItemDetails, queryCompletions} from './completions.js';
+import {getWorkerContext} from './worker-context.js';
 
 const workerAPI: WorkerAPI = {
   compileProject: build,
   getCompletions: queryCompletions,
   getCompletionItemDetails: getCompletionItemDetails,
+  getFreshWorkerContext(config: WorkerConfig) {
+    getWorkerContext(config, true);
+  },
 };
 expose(workerAPI);

--- a/src/typescript-worker/typescript-builder.ts
+++ b/src/typescript-worker/typescript-builder.ts
@@ -79,7 +79,13 @@ export async function* processTypeScriptFiles(
   // If a file is removed, it will be removed from the file list
   langServiceHost.sync(loadedFiles);
 
-  const program = langService.getProgram();
+  let program;
+  try {
+    program = langService.getProgram();
+  } catch (e) {
+    yield {kind: 'crash', msg: String(e)};
+    throw e;
+  }
   if (program === undefined) {
     throw new Error('Unexpected error: program was undefined');
   }

--- a/src/typescript-worker/worker-context.ts
+++ b/src/typescript-worker/worker-context.ts
@@ -13,13 +13,22 @@ let workerContext: WorkerContext | undefined;
 let cacheKey = '';
 
 /**
- * Acquire the existing worker instance, or create a fresh one if missing.
- * If the config differs from the existing instance's config, a new WorkerContext is
- * instantiated and made the new instance.
+ * Acquire the existing worker instance, or create a fresh one if missing. If
+ * the config differs from the existing instance's config, a new WorkerContext
+ * is instantiated and made the new instance.
+ *
+ * @param forceFreshWorkerContext - When true will return a new WorkerContext instance ignoring cache.
  */
-export function getWorkerContext(config: WorkerConfig) {
+export function getWorkerContext(
+  config: WorkerConfig,
+  forceFreshWorkerContext = false
+) {
   const configCacheKey = JSON.stringify(config);
-  if (workerContext && cacheKey === configCacheKey) {
+  if (
+    workerContext &&
+    cacheKey === configCacheKey &&
+    !forceFreshWorkerContext
+  ) {
     return workerContext;
   }
 


### PR DESCRIPTION
### Context

This fixes https://github.com/lit/lit.dev/issues/1128 by providing a path to gracefully recover from bad incremental state.

### Testing

Manually confirmed this fix works - investigating adding unit testing.

Note that for the specific case that this PR was created, it's also viable to upgrade the bundled TypeScript which resolves the compiler error. A benefit of this solution is we could use it for other rare exceptions in the future.