### PR TITLE
Add missing tag links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,12 +1135,91 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix missing CodeMirror styles on Firefox and Safari.
 - Fix Safari crashes in `<mwc-tab>` code.
 
-## [0.1.0-pre.2] - 2020-09-12
+## 0.1.0-pre.2 - 2020-09-12
 
 ### Fixed
 
 - Fix extra/missing files.
 
-## [0.1.0-pre.1] - 2020-09-12
+## 0.1.0-pre.1 - 2020-09-12
 
 - Initial release.
+
+[0.18.0]: https://github.com/google/playground-elements/compare/v0.17.1...v0.18.0
+[0.17.1]: https://github.com/google/playground-elements/compare/v0.17.0...v0.17.1
+[0.17.0]: https://github.com/google/playground-elements/compare/v0.16.3...v0.17.0
+[0.16.3]: https://github.com/google/playground-elements/compare/v0.16.2...v0.16.3
+[0.16.2]: https://github.com/google/playground-elements/compare/v0.16.1...v0.16.2
+[0.16.1]: https://github.com/google/playground-elements/compare/v0.16.0...v0.16.1
+[0.16.0]: https://github.com/google/playground-elements/compare/v0.15.5...v0.16.0
+[0.15.5]: https://github.com/google/playground-elements/compare/v0.15.4...v0.15.5
+[0.15.4]: https://github.com/google/playground-elements/compare/v0.15.3...v0.15.4
+[0.15.3]: https://github.com/google/playground-elements/compare/v0.15.2...v0.15.3
+[0.15.2]: https://github.com/google/playground-elements/compare/v0.15.1...v0.15.2
+[0.15.1]: https://github.com/google/playground-elements/compare/v0.15.0...v0.15.1
+[0.15.0]: https://github.com/google/playground-elements/compare/v0.15.0-pre.5...v0.15.0
+[0.15.0-pre.5]: https://github.com/google/playground-elements/compare/v0.15.0-pre.4...v0.15.0-pre.5
+[0.15.0-pre.4]: https://github.com/google/playground-elements/compare/v0.15.0-pre.3...v0.15.0-pre.4
+[0.15.0-pre.3]: https://github.com/google/playground-elements/compare/v0.15.0-pre.2...v0.15.0-pre.3
+[0.15.0-pre.2]: https://github.com/google/playground-elements/compare/v0.15.0-pre.1...v0.15.0-pre.2
+[0.15.0-pre.1]: https://github.com/google/playground-elements/compare/v0.14.8...v0.15.0
+[0.14.8]: https://github.com/google/playground-elements/compare/v0.14.7...v0.14.8
+[0.14.7]: https://github.com/google/playground-elements/compare/v0.14.6...v0.14.7
+[0.14.6]: https://github.com/google/playground-elements/compare/v0.14.5...v0.14.6
+[0.14.5]: https://github.com/google/playground-elements/compare/v0.14.4...v0.14.5
+[0.14.4]: https://github.com/google/playground-elements/compare/v0.14.3...v0.14.4
+[0.14.3]: https://github.com/google/playground-elements/compare/v0.14.2...v0.14.3
+[0.14.2]: https://github.com/google/playground-elements/compare/v0.14.1...v0.14.2
+[0.14.1]: https://github.com/google/playground-elements/compare/v0.14.0...v0.14.1
+[0.14.0]: https://github.com/google/playground-elements/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/google/playground-elements/compare/v0.12.1...v0.13.0
+[0.12.1]: https://github.com/google/playground-elements/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/google/playground-elements/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/google/playground-elements/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/google/playground-elements/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/google/playground-elements/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/google/playground-elements/compare/v0.9.4...v0.10.0
+[0.9.4]: https://github.com/google/playground-elements/compare/v0.9.3...v0.9.4
+[0.9.3]: https://github.com/google/playground-elements/compare/v0.9.2...v0.9.3
+[0.9.2]: https://github.com/google/playground-elements/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/google/playground-elements/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/google/playground-elements/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/google/playground-elements/compare/v0.7.0...v0.8.0   
+[0.7.0]: https://github.com/google/playground-elements/compare/v0.6.6...v0.7.0
+[0.6.6]: https://github.com/google/playground-elements/compare/v0.6.5...v0.6.6
+[0.6.5]: https://github.com/google/playground-elements/compare/v0.6.4...v0.6.5
+[0.6.4]: https://github.com/google/playground-elements/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/google/playground-elements/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/google/playground-elements/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/google/playground-elements/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/google/playground-elements/compare/v0.6.0...v0.6.0
+[0.5.0]: https://github.com/google/playground-elements/compare/v0.4.3...v0.5.0
+[0.4.3]: https://github.com/google/playground-elements/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/google/playground-elements/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/google/playground-elements/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/google/playground-elements/compare/v0.3.7...v0.4.0
+[0.3.7]: https://github.com/google/playground-elements/compare/v0.3.6...v0.3.7
+[0.3.6]: https://github.com/google/playground-elements/compare/v0.3.5...v0.3.6
+[0.3.5]: https://github.com/google/playground-elements/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/google/playground-elements/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/google/playground-elements/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/google/playground-elements/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/google/playground-elements/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/google/playground-elements/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/google/playground-elements/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/google/playground-elements/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/google/playground-elements/compare/v0.1.0-pre.4...v0.1.0
+[0.1.0-pre.4]: https://github.com/google/playground-elements/compare/v0.1.0-pre.3...v0.1.0-pre.4
+[0.1.0-pre.3]: https://github.com/google/playground-elements/releases/tag/v0.1.0-pre.3
+   
+   
+   
+   
+  
+   
+   
+   
+
+   
+   
+   


### PR DESCRIPTION
This PR adds the missing tag / version comparison links as per https://keepachangelog.com/en/1.1.0/