### PR TITLE
Fix tab to spaces replacement logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix tab-to-spaces conversion in the code editor which was resulting in one less space being produced on tab than desired.
+
 ## [0.18.0] - 2023-05-25
 
 ### Changed

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -478,7 +478,7 @@ export class PlaygroundCodeEditor extends LitElement {
         extraKeys: {
           Tab: () => {
             cm.replaceSelection(
-              Array(cm.getOption('indentUnit') ?? 2).join(' ')
+              Array((cm.getOption('indentUnit') ?? 2) + 1).join(' ')
             );
           },
           // Ctrl + Space requests code completions.


### PR DESCRIPTION
The existing implementation of converting a tab into spaces inadvertently includes an off-by-one error, producing one less space than desired. Resolves #358. 