### PR TITLE
Add open preview in new tab button

### DIFF
--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -49,7 +49,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
       margin: 0 10px;
     }
 
-    #reload-button {
+    #actions > mwc-icon-button {
       --mdc-icon-button-size: 30px;
       --mdc-icon-size: 18px;
     }
@@ -195,26 +195,49 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     return html`
       <div id="toolbar" part="preview-toolbar">
         <span id="location" part="preview-location"> ${this.location}</span>
-        <mwc-icon-button
-          id="reload-button"
-          aria-label="Reload preview"
-          part="preview-reload-button"
-          ?disabled=${!this._indexUrl}
-          @click=${this.reload}
-        >
-          <!-- Source: https://material.io/resources/icons/?icon=refresh&style=baseline -->
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentcolor"
-            width="18px"
-            height="18px"
+        <div id="actions">
+          <mwc-icon-button
+            id="open-new-tab-button"
+            aria-label="Open preview in new tab"
+            part="preview-open-new-tab-button"
+            ?disabled=${!this._indexUrl}
+            @click=${this.openPreviewInNewTab}
           >
-            <path
-              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-            />
-          </svg>
-        </mwc-icon-button>
+            <!-- Source: https://fonts.google.com/icons?selected=Material%20Icons%3Aopen_in_new%3A -->
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentcolor"
+              width="18px"
+              height="18px"
+            >
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path
+                d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+              />
+            </svg>
+          </mwc-icon-button>
+          <mwc-icon-button
+            id="reload-button"
+            aria-label="Reload preview"
+            part="preview-reload-button"
+            ?disabled=${!this._indexUrl}
+            @click=${this.reload}
+          >
+            <!-- Source: https://material.io/resources/icons/?icon=refresh&style=baseline -->
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentcolor"
+              width="18px"
+              height="18px"
+            >
+              <path
+                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+              />
+            </svg>
+          </mwc-icon-button>
+        </div>
       </div>
 
       <div id="content" class=${classMap({error: !!this._error})}>
@@ -325,6 +348,10 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
       this._loadedAtLeastOnce = true;
       this._showLoadingBar = false;
     }
+  }
+
+  openPreviewInNewTab() {
+    window.open(this._indexUrl, '_blank');
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/google/playground-elements/issues/354

This change adds an icon button in the toolbar of the preview panel so users can open the preview in a new tab.