### PR TITLE
Use the void operator to mark floating promises.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,9 +17,6 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
-    // Google internally requires that floating promises are annotated with a
-    // special function. We use eslint-enable and eslint-disable comments for
-    // this rule to identify these spots for automated transform on import.
     "@typescript-eslint/no-floating-promises": "error"
   },
   "overrides": [

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -321,9 +321,7 @@ export class PlaygroundCodeEditor extends LitElement {
               // Swapping to a document instance doesn't trigger a change event
               // which is required for document folding. Manually fold once on
               // document instantiation.
-              /* eslint-disable @typescript-eslint/no-floating-promises */
-              this._applyHideAndFoldRegions();
-              /* eslint-enable @typescript-eslint/no-floating-promises */
+              void this._applyHideAndFoldRegions();
             }
             this._valueChangingFromOutside = false;
             break;
@@ -356,9 +354,7 @@ export class PlaygroundCodeEditor extends LitElement {
             cm.setOption('readOnly', this.readonly);
             break;
           case 'pragmas':
-            /* eslint-disable @typescript-eslint/no-floating-promises */
-            this._applyHideAndFoldRegions();
-            /* eslint-enable @typescript-eslint/no-floating-promises */
+            void this._applyHideAndFoldRegions();
             break;
           case 'diagnostics':
             this._showDiagnostics();
@@ -501,9 +497,7 @@ export class PlaygroundCodeEditor extends LitElement {
       // file it is displaying.
       if (this._valueChangingFromOutside) {
         // Users can't change hide/fold regions.
-        /* eslint-disable @typescript-eslint/no-floating-promises */
-        this._applyHideAndFoldRegions();
-        /* eslint-enable @typescript-eslint/no-floating-promises */
+        void this._applyHideAndFoldRegions();
         this._showDiagnostics();
       } else {
         this.dispatchEvent(new Event('change'));
@@ -738,8 +732,7 @@ export class PlaygroundCodeEditor extends LitElement {
     // The detail promise is passed into this function only for the item
     // currently highlighted from the completions list.
     if (detail !== undefined) {
-      /* eslint-disable @typescript-eslint/no-floating-promises */
-      detail.then((detailResult: EditorCompletionDetails) => {
+      void detail.then((detailResult: EditorCompletionDetails) => {
         this._renderCompletionItemWithDetails(
           objectName,
           detailResult,
@@ -753,7 +746,6 @@ export class PlaygroundCodeEditor extends LitElement {
           this._renderHint(element, _data, hint);
         this._currentCompletionSelectionLabel = hint.text;
       });
-      /* eslint-enable @typescript-eslint/no-floating-promises */
     }
   }
 

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -308,9 +308,7 @@ export class PlaygroundProject extends LitElement {
 
   override async update(changedProperties: PropertyValues) {
     if (changedProperties.has('_source')) {
-      /* eslint-disable @typescript-eslint/no-floating-promises */
-      this._loadProjectFromSource();
-      /* eslint-enable @typescript-eslint/no-floating-promises */
+      void this._loadProjectFromSource();
     }
     if (
       changedProperties.has('sandboxScope') ||
@@ -362,7 +360,8 @@ export class PlaygroundProject extends LitElement {
           this._importMap = importMap;
         }
         break;
-      default: // Exhaustive check.
+      default:
+        // Exhaustive check.
         source as void;
         break;
     }
@@ -370,9 +369,7 @@ export class PlaygroundProject extends LitElement {
       this._files && (JSON.parse(JSON.stringify(this._files)) as SampleFile[]);
     this._modified = false;
     this.dispatchEvent(new FilesChangedEvent(true));
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    this.save();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
+    void this.save();
   }
 
   override render() {
@@ -496,14 +493,12 @@ export class PlaygroundProject extends LitElement {
         port.removeEventListener('message', onMessage);
         if (e.data.version === serviceWorkerHash) {
           this._serviceWorkerAPI = wrap<ServiceWorkerAPI>(port);
-          /* eslint-disable @typescript-eslint/no-floating-promises */
-          this._serviceWorkerAPI.setFileAPI(
+          void this._serviceWorkerAPI.setFileAPI(
             proxy({
               getFile: (name: string) => this._getFile(name),
             }),
             this._sessionId
           );
-          /* eslint-enable @typescript-eslint/no-floating-promises */
         } else {
           // Version mismatch. Request the service worker be updated
           // immediately. We'll get back here again after it updates via a
@@ -568,13 +563,11 @@ export class PlaygroundProject extends LitElement {
     if (build.state() !== 'active') {
       return;
     }
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    workerApi.compileProject(
+    void workerApi.compileProject(
       this._files ?? [],
       {importMap: this._importMap},
       proxy((result) => build.onOutput(result))
     );
-    /* eslint-enable @typescript-eslint/no-floating-promises */
     await build.stateChange;
     if (build.state() !== 'done') {
       return;
@@ -688,9 +681,7 @@ export class PlaygroundProject extends LitElement {
     // want to be doing any searches.
     file.content = newContent;
     this._modified = undefined;
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    this.saveDebounced();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
+    void this.saveDebounced();
   }
 
   addFile(name: string) {
@@ -712,9 +703,7 @@ export class PlaygroundProject extends LitElement {
     this._modified = undefined;
     this.requestUpdate();
     this.dispatchEvent(new FilesChangedEvent());
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    this.save();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
+    void this.save();
   }
 
   deleteFile(filename: string) {
@@ -728,9 +717,7 @@ export class PlaygroundProject extends LitElement {
     this._files = [...this._files.slice(0, idx), ...this._files.slice(idx + 1)];
     this._modified = undefined;
     this.dispatchEvent(new FilesChangedEvent());
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    this.save();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
+    void this.save();
   }
 
   renameFile(oldName: string, newName: string) {
@@ -750,9 +737,7 @@ export class PlaygroundProject extends LitElement {
     this._files = [...this._files];
     this._modified = undefined;
     this.dispatchEvent(new FilesChangedEvent());
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    this.save();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
+    void this.save();
   }
 }
 

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -13,8 +13,7 @@ import {
   UPDATE_SERVICE_WORKER,
 } from './shared/worker-api.js';
 
-/* eslint-disable @typescript-eslint/no-floating-promises */
-(async () => {
+void (async () => {
   try {
     // Note we detect same-origin here by actually trying to access the parent
     // window. We can't trust the parent to compare the origins of the URLs,
@@ -114,16 +113,12 @@ import {
     sw.postMessage(swMessage, [port2]);
   };
 
-  /* eslint-disable @typescript-eslint/no-floating-promises */
-  connectToNewest();
-  /* eslint-enable @typescript-eslint/no-floating-promises */
+  void connectToNewest();
 
   registration.addEventListener('updatefound', () => {
     // We can get a new service worker at any time, so we need to listen for
     // updates and connect to new workers on demand.
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    connectToNewest();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
+    void connectToNewest();
   });
 
   // A message from the service worker.
@@ -143,9 +138,7 @@ import {
         // Force required because we usually avoid connecting to a service
         // worker we've already connected to, but in this case that's exactly
         // what we must do.
-        /* eslint-disable @typescript-eslint/no-floating-promises */
-        connectToNewest(true);
-        /* eslint-enable @typescript-eslint/no-floating-promises */
+        void connectToNewest(true);
       }
     }
   );
@@ -177,4 +170,3 @@ import {
     }
   );
 })();
-/* eslint-enable @typescript-eslint/no-floating-promises */

--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -151,9 +151,7 @@ const parseScopedUrl = (url: string) => {
 const onInstall = () => {
   // Force this service worker to become the active service worker, in case
   // it's an updated worker and waiting.
-  /* eslint-disable @typescript-eslint/no-floating-promises */
-  self.skipWaiting();
-  /* eslint-enable @typescript-eslint/no-floating-promises */
+  void self.skipWaiting();
 };
 
 const onActivate = (event: ExtendableEvent) => {

--- a/src/typescript-worker/util.ts
+++ b/src/typescript-worker/util.ts
@@ -37,8 +37,7 @@ export class MergedAsyncIterables<T> {
       );
     }
     this._numSources++;
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    (async () => {
+    void (async () => {
       for await (const value of iterable) {
         // Wait for this value to be emitted before continuing
         await new Promise<void>((emitted) => {
@@ -49,7 +48,6 @@ export class MergedAsyncIterables<T> {
       this._numSources--;
       this._notify?.();
     })();
-    /* eslint-enable @typescript-eslint/no-floating-promises */
   }
 }
 


### PR DESCRIPTION
Even internally, noAwait is now discouraged.