### PR TITLE
feat(cdn): allows customization of the CDN base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Set the `project-src` attribute or `projectSrc` property to a JSON file with for
 | `files.hidden`      | If `true`, the file won't be visible in `playground-tab-bar`.                                                                                                                    |
 | `files.selected`    | If `true`, this file's tab will be selected when the project is loaded. Only one file should have this field set.                                                                |
 | `extends`           | Optional URL to another JSON config file to extend from. Configs are deeply merged. URLs are interpreted relative to the URL of each extendee config.                            |
+| `cdnBaseUrl`        | Optional URL for the underlying npm CDN base url. Confirmed tested are `htts://unpkg.com` and `https://cdn.jsdelivr.net/npm`                                                     |
 
 ```html
 <playground-ide project-src="/path/to/my/project.json"> </playground-ide>
@@ -259,7 +260,7 @@ precedence. When either are set, inline scripts are ignored.
 
 By default, bare module specifiers in JavaScript and TypeScript files are
 transformed to special `./node_modules/` URLs, and fetched behind-the-scenes
-from unpkg.com at the latest version.
+from unpkg.com by default at the latest version.
 
 ```js
 // What you write:
@@ -268,7 +269,7 @@ import {html} from 'lit';
 // What playground serves:
 import {html} from './node_modules/lit@2.0.2/index.js';
 
-// What playground fetches behind-the-scenes:
+// What playground fetches behind-the-scenes unless you set `cdnBaseUrl`:
 // https://unpkg.com/lit@latest
 ```
 
@@ -335,7 +336,7 @@ When using inline project files, you can specify your import map like so:
 ```
 
 If an import map is defined, but does not contain an entry for a bare module,
-then playground defaults to the `unpkg.com` URL.
+then playground defaults to the `unpkg.com` URL unless `cdnBaseUrl` is set.
 
 ## TypeScript
 
@@ -564,9 +565,10 @@ unprivileged and cannot modify the host window.
 You may wish to override this default sandbox base URL if you do not want a
 dependency on `unpkg.com`, e.g. for isolation from outages, or because your
 network does not have access to it. Note that Playground currently also uses
-`unpkg.com` to retrieve imported bare modules that are not otherwise handled by
-an [import map](#module-resolution), so the `unpkg.com` dependency cannot
-currently be completely eliminated.
+`unpkg.com` by default (unless you set `cdnBaseUrl`) to retrieve imported bare
+modules that are not otherwise handled by an [import map](#module-resolution),
+so to remove the dependency on unpkg, you should also set `cdnBaseUrl`. See the
+API docs for more info.
 
 ### Background
 
@@ -680,6 +682,7 @@ All-in-one project, editor, file switcher, and preview with a horizontal side-by
 | -------------------- | -------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `projectSrc`         | `string`                         | `undefined`               | URL of the [project manifest](#project-manifest) to load                                                                                                                                           |
 | `config`             | `ProjectManifest`                | `undefined`               | Get or set the project configuration and files, ([details](#option-3-config-property)).                                                                                                            |
+| `cdnBaseUrl`         | `string`                         | `https://unpkg.com`       | Change the underlying npm CDN base url. Confirmed tested are `htts://unpkg.com` and `https://cdn.jsdelivr.net/npm`                                                                                 |
 | `lineNumbers`        | `boolean`                        | `false`                   | Render a gutter with line numbers in the editor                                                                                                                                                    |
 | `lineWrapping`       | `boolean`                        | `false`                   | If `true`, long lines are wrapped, otherwise the editor will scroll.                                                                                                                               |
 | `editableFileSystem` | `boolean`                        | `false`                   | Allow adding, removing, and renaming files                                                                                                                                                         |
@@ -710,6 +713,7 @@ project element.
 | ---------------- | ----------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `projectSrc`     | `string`                      | `undefined`               | URL of a [project files manifest](#option-2-json-manifest) to load.                                                                                                                                |
 | `config`         | `ProjectManifest`             | `undefined`               | Get or set the project configuration and files, ([details](#option-3-config-property)).                                                                                                            |
+| `cdnBaseUrl`     | `string`                      | `https://unpkg.com`       | Change the underlying npm CDN base url. Confirmed tested are `htts://unpkg.com` and `https://cdn.jsdelivr.net/npm`                                                                                 |
 | `sandboxScope`   | `string`                      | `"playground-elements"`   | The service worker scope to register on.                                                                                                                                                           |
 | `sandboxBaseUrl` | `string`                      | _module parent directory_ | Base URL for untrusted JavaScript execution (⚠️ use with caution, see [sandbox security](#sandbox-security)). Resolved relative to the module containing the definition of `<playground-project>`. |
 | `diagnostics`    | `Map<string, lsp.Diagnostic>` | `undefined`               | Map from filename to array of Language Server Protocol diagnostics resulting from the latest compilation.                                                                                          |

--- a/configurator/project/package.json
+++ b/configurator/project/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "lit": "^2.0.0",
-    "@lit/reactive-element": "^1.0.0",
-    "lit-element": "^3.0.0",
-    "lit-html": "^2.0.0"
+    "lit": "^3.0.0",
+    "@lit/reactive-element": "^2.0.0",
+    "lit-element": "^4.0.0",
+    "lit-html": "^3.0.0"
   }
 }

--- a/src/configurator/knobs.ts
+++ b/src/configurator/knobs.ts
@@ -47,6 +47,12 @@ interface SelectKnob<Id extends string, T extends string>
   options: ReadonlyArray<T>;
 }
 
+interface InputKnob<Id extends string> extends BaseKnob<Id, string> {
+  type: 'input';
+  placeholder?: string;
+  inputType?: string;
+}
+
 function checkbox<Id extends string>(
   def: Omit<CheckboxKnob<Id>, 'type'>
 ): CheckboxKnob<Id> {
@@ -69,6 +75,12 @@ function select<Id extends string, T extends string>(
   def: Omit<SelectKnob<Id, T>, 'type'>
 ): SelectKnob<Id, T> {
   return {type: 'select', ...def};
+}
+
+function input<Id extends string>(
+  def: Omit<InputKnob<Id>, 'type'>
+): InputKnob<Id> {
+  return {type: 'input', ...def};
 }
 
 const pixels = (value: number) => value + 'px';
@@ -120,6 +132,14 @@ export const knobs = [
   }),
 
   // features
+  input({
+    id: 'cdnBaseUrl',
+    label: 'CDN Base URL',
+    section: 'features',
+    default: 'https://unpkg.com',
+    htmlAttribute: 'cdn-base-url',
+    inputType: 'text',
+  }),
   checkbox({
     id: 'resizable',
     label: 'Resizable',

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -218,6 +218,16 @@ export class PlaygroundIde extends LitElement {
   sandboxScope = `__playground_swfs_${serviceWorkerHash}/`;
 
   /**
+   * Base URL for the CDN used to resolve bare module specifiers.
+   *
+   * Examples:
+   * - "https://unpkg.com" (default)
+   * - "https://cdn.jsdelivr.net/npm"
+   */
+  @property({attribute: 'cdn-base-url'})
+  cdnBaseUrl = 'https://unpkg.com';
+
+  /**
    * Allow the user to add, remove, and rename files in the project's virtual
    * filesystem. Disabled by default.
    */
@@ -299,6 +309,7 @@ export class PlaygroundIde extends LitElement {
         id=${projectId}
         .sandboxBaseUrl=${this.sandboxBaseUrl}
         .sandboxScope=${this.sandboxScope}
+        .cdnBaseUrl=${this.cdnBaseUrl}
       >
         <slot></slot>
       </playground-project>

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -74,7 +74,7 @@ export interface ServiceWorkerAPI {
 
 export interface WorkerConfig {
   importMap: ModuleImportMap;
-  cdnBaseUrl?: string;
+  cdnBaseUrl: string;
 }
 
 export interface EditorToken {
@@ -187,6 +187,7 @@ export interface ProjectManifest {
   extends?: string;
   files?: {[filename: string]: FileOptions};
   importMap?: ModuleImportMap;
+  cdnBaseUrl?: string;
 }
 
 export interface ModuleImportMap {

--- a/src/test/cdn-base-url_test.ts
+++ b/src/test/cdn-base-url_test.ts
@@ -1,0 +1,340 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {assert} from '@esm-bundle/chai';
+import {checkTransform} from './worker-test-util.js';
+import {PlaygroundProject} from '../playground-project.js';
+import {PlaygroundIde} from '../playground-ide.js';
+import {
+  SampleFile,
+  BuildOutput,
+  ProjectManifest,
+  DiagnosticBuildOutput,
+} from '../shared/worker-api.js';
+import {CdnData} from './fake-cdn-plugin.js';
+
+suite('CDN Base URL Configuration', () => {
+  let container: HTMLDivElement;
+
+  setup(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  teardown(() => {
+    container.remove();
+  });
+
+  suite('CachingCdn URL Handling', () => {
+    test('resolves bare modules using CDN base URL', async () => {
+      const files: SampleFile[] = [
+        {
+          name: 'index.ts',
+          content: `
+            import {html} from "lit";
+            console.log(html\`Hello\`);
+          `,
+        },
+      ];
+      const cdn: CdnData = {
+        lit: {
+          versions: {
+            '2.0.0': {
+              files: {
+                'package.json': {
+                  content: '{"main": "index.js"}',
+                },
+                'index.js': {
+                  content:
+                    'export const html = (strings, ...values) => ({ strings, values });',
+                },
+                'index.d.ts': {
+                  content:
+                    'export declare const html: (strings: TemplateStringsArray, ...values: unknown[]) => unknown;',
+                },
+              },
+            },
+          },
+        },
+      };
+      const expected: BuildOutput[] = [
+        {
+          kind: 'diagnostic',
+          filename: 'index.ts',
+          diagnostic: {
+            code: 2307,
+            message:
+              "Cannot find module 'lit' or its corresponding type declarations.",
+            range: {
+              start: {
+                line: 1,
+                character: 31,
+              },
+              end: {
+                line: 1,
+                character: 36,
+              },
+            },
+            severity: 1,
+            source: 'typescript',
+          },
+        } as DiagnosticBuildOutput,
+        {
+          kind: 'diagnostic',
+          filename: 'index.ts',
+          diagnostic: {
+            code: 2584,
+            message:
+              "Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.",
+            range: {
+              start: {line: 2, character: 12},
+              end: {line: 2, character: 19},
+            },
+            severity: 1,
+            source: 'typescript',
+          },
+        } as DiagnosticBuildOutput,
+        {
+          kind: 'file',
+          file: {
+            name: 'index.js',
+            content:
+              'import { html } from "lit@2.0.0";\nconsole.log(html `Hello`);\n',
+            contentType: 'text/javascript',
+          },
+        },
+      ];
+
+      // Create a spy to capture the URL used for fetching
+      let capturedUrl: string | null = null;
+      const originalFetch = window.fetch;
+      window.fetch = function (
+        url: string | URL | Request,
+        init?: RequestInit
+      ) {
+        const urlString =
+          url instanceof URL
+            ? url.toString()
+            : url instanceof Request
+            ? url.url
+            : url;
+        if (urlString.includes('lit')) {
+          console.log('Captured URL:', urlString);
+          capturedUrl = urlString;
+        }
+        return originalFetch(url, init);
+      } as typeof window.fetch;
+
+      try {
+        // Import map is configured to use the CDN via the fake CDN provider
+        await checkTransform(
+          files,
+          expected,
+          {
+            imports: {
+              lit: 'lit@2.0.0',
+            },
+          },
+          cdn
+        );
+
+        // Verify the correct CDN URL was used
+        assert.exists(capturedUrl, 'A CDN URL should have been captured');
+        assert.include(
+          capturedUrl!,
+          '/fake-cdn/',
+          'The CDN URL should include the fake CDN path'
+        );
+        assert.include(
+          capturedUrl!,
+          'lit@',
+          'The CDN URL should include the package name'
+        );
+      } finally {
+        window.fetch = originalFetch;
+      }
+    });
+
+    test('uses default CDN base URL when not specified', async () => {
+      const files: SampleFile[] = [
+        {
+          name: 'index.ts',
+          content: `
+            import {html} from "lit";
+            console.log(html\`Hello\`);
+          `,
+        },
+      ];
+      const cdn: CdnData = {
+        lit: {
+          versions: {
+            '2.0.0': {
+              files: {
+                'package.json': {
+                  content: '{"main": "index.js"}',
+                },
+                'index.js': {
+                  content:
+                    'export const html = (strings, ...values) => ({ strings, values });',
+                },
+                'index.d.ts': {
+                  content:
+                    'export declare const html: (strings: TemplateStringsArray, ...values: unknown[]) => unknown;',
+                },
+              },
+            },
+          },
+        },
+      };
+      const expected: BuildOutput[] = [
+        {
+          kind: 'diagnostic',
+          filename: 'index.ts',
+          diagnostic: {
+            code: 2307,
+            message:
+              "Cannot find module 'lit' or its corresponding type declarations.",
+            range: {
+              start: {
+                line: 1,
+                character: 31,
+              },
+              end: {
+                line: 1,
+                character: 36,
+              },
+            },
+            severity: 1,
+            source: 'typescript',
+          },
+        } as DiagnosticBuildOutput,
+        {
+          kind: 'diagnostic',
+          filename: 'index.ts',
+          diagnostic: {
+            code: 2584,
+            message:
+              "Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.",
+            range: {
+              start: {line: 2, character: 12},
+              end: {line: 2, character: 19},
+            },
+            severity: 1,
+            source: 'typescript',
+          },
+        } as DiagnosticBuildOutput,
+        {
+          kind: 'file',
+          file: {
+            name: 'index.js',
+            content:
+              'import { html } from "lit@2.0.0";\nconsole.log(html `Hello`);\n',
+            contentType: 'text/javascript',
+          },
+        },
+      ];
+
+      // Test with default CDN base URL
+      await checkTransform(
+        files,
+        expected,
+        {
+          imports: {
+            lit: 'lit@2.0.0',
+          },
+        },
+        cdn
+      );
+    });
+  });
+
+  suite('PlaygroundProject CDN base URL', () => {
+    test('sets cdnBaseUrl property', async () => {
+      const project = document.createElement(
+        'playground-project'
+      ) as PlaygroundProject;
+      project.cdnBaseUrl = 'https://cdn.jsdelivr.net/npm';
+      container.appendChild(project);
+      await project.updateComplete;
+      assert.equal(project.cdnBaseUrl, 'https://cdn.jsdelivr.net/npm');
+    });
+  });
+
+  suite('PlaygroundIDE CDN base URL', () => {
+    test('passes cdnBaseUrl property to playground-project', async function () {
+      // Increase timeout for this test
+      this.timeout(10000);
+
+      // Import the component first
+      await import('../playground-ide.js');
+
+      const ide = document.createElement('playground-ide') as PlaygroundIde;
+      ide.cdnBaseUrl = 'https://cdn.jsdelivr.net/npm';
+      container.appendChild(ide);
+
+      // Wait for component to initialize
+      await ide.updateComplete;
+
+      // Wait for a bit to ensure shadow DOM is created
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Ensure shadow root exists
+      assert.exists(ide.shadowRoot, 'IDE should have a shadow root');
+
+      // Get and check the project component
+      const project = ide.shadowRoot!.querySelector(
+        'playground-project'
+      ) as PlaygroundProject;
+      assert.exists(project, 'Playground project should exist in shadow root');
+
+      // Wait for project to update
+      await project.updateComplete;
+
+      // Check the CDN property
+      assert.equal(project.cdnBaseUrl, 'https://cdn.jsdelivr.net/npm');
+    });
+  });
+
+  suite('End-to-end CDN URL resolution', () => {
+    test('correctly resolves modules using the configured CDN base URL', async function () {
+      this.timeout(10000);
+
+      // Create a playground-ide with custom CDN base URL
+      const ide = document.createElement('playground-ide') as PlaygroundIde;
+      const customCdnBaseUrl = 'https://custom-cdn.example.com/packages';
+      ide.cdnBaseUrl = customCdnBaseUrl;
+
+      // Add a simple project that imports from a bare module
+      const projectConfig: ProjectManifest = {
+        files: {
+          'index.ts': {
+            content: 'import {html} from "lit";\nconsole.log(html`Hello`);',
+          },
+        },
+        importMap: {
+          imports: {
+            lit: 'lit@2.0.0',
+          },
+        },
+      };
+
+      ide.config = projectConfig;
+
+      container.appendChild(ide);
+      await ide.updateComplete;
+
+      // Get the project component and verify its CDN base URL
+      const project = ide.shadowRoot!.querySelector(
+        'playground-project'
+      ) as PlaygroundProject;
+      assert.equal(
+        project.cdnBaseUrl,
+        customCdnBaseUrl,
+        'CDN base URL should be passed from IDE to project'
+      );
+    });
+  });
+});

--- a/src/typescript-worker/worker-context.ts
+++ b/src/typescript-worker/worker-context.ts
@@ -35,7 +35,7 @@ export class WorkerContext {
 
   constructor(config: WorkerConfig) {
     this.importMapResolver = new ImportMapResolver(config.importMap);
-    this.cdn = new CachingCdn(config.cdnBaseUrl ?? 'https://unpkg.com/');
+    this.cdn = new CachingCdn(config.cdnBaseUrl || 'https://unpkg.com');
     this.languageServiceContext = new LanguageServiceContext();
   }
 }


### PR DESCRIPTION
Allows for setting the CDN base url. Currently only tested is unpkg and https://cdn.jsdelivr.net/npm via the `cdnBaseUrl` property and config entry