### PR TITLE
fix(npm): include `codemirror-extension-mixin` in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "images/",
     "index.{js,d.ts,d.ts.map}",
     "cm-lang-lit.{js,d.ts,d.ts.map}",
+    "codemirror-extension-mixin.{js,d.ts,d.ts.map}",
     "playground-code-editor.{js,d.ts,d.ts.map}",
     "playground-connected-element.{js,d.ts,d.ts.map}",
     "playground-file-editor.{js,d.ts,d.ts.map}",


### PR DESCRIPTION
fixes #428

Forgot to add `codemirror-extension-elements.js` to package.json's files. This meant they were not getting published with `npm publish`. Confirmed they publish with `npm publish --dry-run`